### PR TITLE
Refactor paths handling and resolution

### DIFF
--- a/src/device/default.rs
+++ b/src/device/default.rs
@@ -12,7 +12,7 @@ use crate::errno;
 use crate::errno::EResult;
 use crate::errno::Errno;
 use crate::file::blocking::BlockHandler;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::logger::LOGGER;
 use crate::process::mem_space::MemSpace;
 use crate::process::Process;
@@ -260,7 +260,7 @@ impl IO for KMsgDeviceHandle {
 pub(super) fn create() -> EResult<()> {
 	let _first_major = ManuallyDrop::new(id::alloc_major(DeviceType::Char, Some(1))?);
 
-	let null_path = Path::from_str(b"/dev/null", false)?;
+	let null_path = PathBuf::try_from(b"/dev/null")?;
 	let null_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,
@@ -273,7 +273,7 @@ pub(super) fn create() -> EResult<()> {
 	)?;
 	device::register(null_device)?;
 
-	let zero_path = Path::from_str(b"/dev/zero", false)?;
+	let zero_path = PathBuf::try_from(b"/dev/zero")?;
 	let zero_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,
@@ -286,7 +286,7 @@ pub(super) fn create() -> EResult<()> {
 	)?;
 	device::register(zero_device)?;
 
-	let random_path = Path::from_str(b"/dev/random", false)?;
+	let random_path = PathBuf::try_from(b"/dev/random")?;
 	let random_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,
@@ -299,7 +299,7 @@ pub(super) fn create() -> EResult<()> {
 	)?;
 	device::register(random_device)?;
 
-	let urandom_path = Path::from_str(b"/dev/urandom", false)?;
+	let urandom_path = PathBuf::try_from(b"/dev/urandom")?;
 	let urandom_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,
@@ -312,7 +312,7 @@ pub(super) fn create() -> EResult<()> {
 	)?;
 	device::register(urandom_device)?;
 
-	let kmsg_path = Path::from_str(b"/dev/kmsg", false)?;
+	let kmsg_path = PathBuf::try_from(b"/dev/kmsg")?;
 	let kmsg_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,
@@ -327,7 +327,7 @@ pub(super) fn create() -> EResult<()> {
 
 	let _fifth_major = ManuallyDrop::new(id::alloc_major(DeviceType::Char, Some(5))?);
 
-	let current_tty_path = Path::from_str(b"/dev/tty", false)?;
+	let current_tty_path = PathBuf::try_from(b"/dev/tty")?;
 	let current_tty_device = Device::new(
 		DeviceID {
 			type_: DeviceType::Char,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -33,7 +33,7 @@ use crate::file::perm::AccessProfile;
 use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileContent;
 use crate::file::Mode;
-use crate::file::{vfs, FileLocation};
+use crate::file::{vfs};
 use crate::process::mem_space::MemSpace;
 use crate::process::Process;
 use crate::syscall::ioctl;
@@ -216,11 +216,8 @@ impl Device {
 		let resolved = vfs::resolve_path(
 			&path,
 			&ResolutionSettings {
-				root: FileLocation::root(),
-				start: Default::default(),
-				access_profile: &AccessProfile::KERNEL,
 				create: true,
-				follow_links: true,
+				..ResolutionSettings::kernel_follow()
 			},
 		)?;
 		match resolved {
@@ -249,7 +246,7 @@ impl Device {
 	///
 	/// If the file doesn't exist, the function does nothing.
 	pub fn remove_file(&mut self) -> EResult<()> {
-		if let Ok(file_mutex) = vfs::get_file_from_path(&self.path, &ResolutionSettings::default())
+		if let Ok(file_mutex) = vfs::get_file_from_path(&self.path, &ResolutionSettings::kernel_follow())
 		{
 			let mut file = file_mutex.lock();
 			vfs::remove_file(&mut file, &AccessProfile::KERNEL)?;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -214,7 +214,7 @@ impl Device {
 
 		// Resolve path
 		let resolved = vfs::resolve_path(
-			&path,
+			path,
 			&ResolutionSettings {
 				create: true,
 				..ResolutionSettings::kernel_follow()
@@ -286,7 +286,7 @@ static DEVICES: Mutex<HashMap<DeviceID, Arc<Mutex<Device>>>> = Mutex::new(HashMa
 /// If files management is initialized, the function creates the associated device file.
 pub fn register(device: Device) -> Result<(), Errno> {
 	let id = device.id.clone();
-	let path = device.get_path().try_clone()?;
+	let path = device.get_path().to_path_buf()?;
 	let mode = device.get_mode();
 
 	// Insert

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -30,10 +30,10 @@ use crate::errno::{AllocResult, CollectResult, EResult};
 use crate::file;
 use crate::file::path::{Path, PathBuf};
 use crate::file::perm::AccessProfile;
+use crate::file::vfs;
 use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileContent;
 use crate::file::Mode;
-use crate::file::{vfs};
 use crate::process::mem_space::MemSpace;
 use crate::process::Process;
 use crate::syscall::ioctl;
@@ -246,7 +246,8 @@ impl Device {
 	///
 	/// If the file doesn't exist, the function does nothing.
 	pub fn remove_file(&mut self) -> EResult<()> {
-		if let Ok(file_mutex) = vfs::get_file_from_path(&self.path, &ResolutionSettings::kernel_follow())
+		if let Ok(file_mutex) =
+			vfs::get_file_from_path(&self.path, &ResolutionSettings::kernel_follow())
 		{
 			let mut file = file_mutex.lock();
 			vfs::remove_file(&mut file, &AccessProfile::KERNEL)?;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -30,9 +30,10 @@ use crate::errno::{AllocResult, CollectResult, EResult};
 use crate::file;
 use crate::file::path::{Path, PathBuf};
 use crate::file::perm::AccessProfile;
-use crate::file::vfs;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileContent;
 use crate::file::Mode;
+use crate::file::{vfs, FileLocation};
 use crate::process::mem_space::MemSpace;
 use crate::process::Process;
 use crate::syscall::ioctl;
@@ -207,37 +208,49 @@ impl Device {
 	/// in order to create the file without a deadlock since the VFS accesses a device to write on
 	/// the filesystem.
 	pub fn create_file(id: &DeviceID, path: &Path, mode: Mode) -> EResult<()> {
-		// If the file already exists, do nothing
-		let exists = vfs::get_file_from_path(&path, &AccessProfile::KERNEL, true).is_ok();
-		if exists {
-			return Ok(());
-		}
+		// Create the parent directory in which the device file is located
+		let parent_path = path.parent().unwrap_or(Path::root());
+		file::util::create_dirs(parent_path)?;
 
-		// Create the directories in which the device file is located
-		let dir_path = path.parent().unwrap_or(Path::root());
-		file::util::create_dirs(dir_path)?;
-		let filename = path.file_name().unwrap().try_into()?;
-
-		// Get the parent directory
-		let parent_mutex = vfs::get_file_from_path(&dir_path, &AccessProfile::KERNEL, true)?;
-		let mut parent = parent_mutex.lock();
-
-		// Create the device file
-		vfs::create_file(
-			&mut parent,
-			filename,
-			&AccessProfile::KERNEL,
-			mode,
-			id.to_file_content(),
+		// Resolve path
+		let resolved = vfs::resolve_path(
+			&path,
+			&ResolutionSettings {
+				root: FileLocation::root(),
+				start: Default::default(),
+				access_profile: &AccessProfile::KERNEL,
+				create: true,
+				follow_links: true,
+			},
 		)?;
-		Ok(())
+		match resolved {
+			Resolved::Creatable {
+				parent,
+				name,
+			} => {
+				let mut parent = parent.lock();
+				let name = name.try_into()?;
+				// Create the device file
+				vfs::create_file(
+					&mut parent,
+					name,
+					&AccessProfile::KERNEL,
+					mode,
+					id.to_file_content(),
+				)?;
+				Ok(())
+			}
+			// The file exists, do nothing
+			Resolved::Found(_) => Ok(()),
+		}
 	}
 
 	/// If exists, removes the device file.
 	///
 	/// If the file doesn't exist, the function does nothing.
 	pub fn remove_file(&mut self) -> EResult<()> {
-		if let Ok(file_mutex) = vfs::get_file_from_path(&self.path, &AccessProfile::KERNEL, true) {
+		if let Ok(file_mutex) = vfs::get_file_from_path(&self.path, &ResolutionSettings::default())
+		{
 			let mut file = file_mutex.lock();
 			vfs::remove_file(&mut file, &AccessProfile::KERNEL)?;
 		}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -246,13 +246,7 @@ impl Device {
 	///
 	/// If the file doesn't exist, the function does nothing.
 	pub fn remove_file(&mut self) -> EResult<()> {
-		if let Ok(file_mutex) =
-			vfs::get_file_from_path(&self.path, &ResolutionSettings::kernel_follow())
-		{
-			let mut file = file_mutex.lock();
-			vfs::remove_file(&mut file, &AccessProfile::KERNEL)?;
-		}
-		Ok(())
+		vfs::remove_file_from_path(&self.path, &ResolutionSettings::kernel_follow())
 	}
 }
 

--- a/src/device/storage/mod.rs
+++ b/src/device/storage/mod.rs
@@ -547,7 +547,7 @@ impl StorageManager {
 				major,
 				minor: storage_id * MAX_PARTITIONS as u32,
 			},
-			main_path,
+			main_path.try_clone()?,
 			STORAGE_MODE,
 			main_handle,
 		)?;

--- a/src/file/fs/ext2/mod.rs
+++ b/src/file/fs/ext2/mod.rs
@@ -245,6 +245,7 @@ fn zero_blocks(
 
 /// The ext2 superblock structure.
 #[repr(C, packed)]
+#[derive(Debug)]
 pub struct Superblock {
 	/// Total number of inodes in the filesystem.
 	total_inodes: u32,
@@ -650,7 +651,8 @@ impl Superblock {
 	}
 }
 
-/// Structure representing a instance of the ext2 filesystem.
+/// An instance of the ext2 filesystem.
+#[derive(Debug)]
 struct Ext2Fs {
 	/// The filesystem's superblock.
 	superblock: Superblock,

--- a/src/file/fs/ext2/mod.rs
+++ b/src/file/fs/ext2/mod.rs
@@ -741,7 +741,7 @@ impl Filesystem for Ext2Fs {
 		self.readonly
 	}
 
-	fn must_cache(&self) -> bool {
+	fn use_cache(&self) -> bool {
 		true
 	}
 

--- a/src/file/fs/ext2/mod.rs
+++ b/src/file/fs/ext2/mod.rs
@@ -28,7 +28,7 @@ mod directory_entry;
 mod inode;
 
 use crate::errno;
-use crate::errno::Errno;
+use crate::errno::{EResult, Errno};
 use crate::file::fs::Filesystem;
 use crate::file::fs::FilesystemType;
 use crate::file::fs::Statfs;
@@ -1113,7 +1113,7 @@ impl Filesystem for Ext2Fs {
 		io: &mut dyn IO,
 		parent_inode: INode,
 		name: &[u8],
-	) -> Result<u16, Errno> {
+	) -> EResult<(u16, INode)> {
 		if unlikely(self.readonly) {
 			return Err(errno!(EROFS));
 		}
@@ -1184,7 +1184,7 @@ impl Filesystem for Ext2Fs {
 		// Writing the inode
 		inode_.write(inode, &self.superblock, io)?;
 
-		Ok(inode_.hard_links_count)
+		Ok((inode_.hard_links_count, inode as _))
 	}
 
 	fn read_node(

--- a/src/file/fs/ext2/mod.rs
+++ b/src/file/fs/ext2/mod.rs
@@ -834,7 +834,9 @@ impl Filesystem for Ext2Fs {
 				FileContent::Directory(final_entries)
 			}
 
-			FileType::Link => FileContent::Link(inode_.get_link(&self.superblock, io)?),
+			FileType::Link => {
+				FileContent::Link(inode_.get_link(&self.superblock, io)?.try_into()?)
+			}
 
 			FileType::Fifo => FileContent::Fifo,
 

--- a/src/file/fs/ext2/mod.rs
+++ b/src/file/fs/ext2/mod.rs
@@ -747,6 +747,10 @@ impl Filesystem for Ext2Fs {
 		true
 	}
 
+	fn get_root_inode(&self) -> INode {
+		inode::ROOT_DIRECTORY_INODE as _
+	}
+
 	fn get_stat(&self, _io: &mut dyn IO) -> Result<Statfs, Errno> {
 		let fragment_size = math::pow2(self.superblock.fragment_size_log + 10);
 
@@ -764,10 +768,6 @@ impl Filesystem for Ext2Fs {
 			f_frsize: fragment_size,
 			f_flags: 0, // TODO
 		})
-	}
-
-	fn get_root_inode(&self, _io: &mut dyn IO) -> Result<INode, Errno> {
-		Ok(inode::ROOT_DIRECTORY_INODE as _)
 	}
 
 	fn get_inode(

--- a/src/file/fs/initramfs/mod.rs
+++ b/src/file/fs/initramfs/mod.rs
@@ -10,7 +10,7 @@ use crate::file;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
-use crate::file::vfs::{ResolutionSettings};
+use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::file::FileContent;
 use crate::file::FileType;

--- a/src/file/fs/initramfs/mod.rs
+++ b/src/file/fs/initramfs/mod.rs
@@ -27,14 +27,14 @@ use cpio::CPIOParser;
 /// - `new` is the new parent's path.
 /// - `stored` is the current parent. The tuple contains the path and the file.
 /// - `retry` tells whether the function is called as a second try.
-fn update_parent(
-	new: &Path,
-	stored: &mut Option<(&Path, Arc<Mutex<File>>)>,
+fn update_parent<'p>(
+	new: &'p Path,
+	stored: &mut Option<(&'p Path, Arc<Mutex<File>>)>,
 	retry: bool,
 ) -> EResult<()> {
 	// Get the parent
 	let result = match stored {
-		Some((path, parent)) if new.starts_with(path) => {
+		Some((path, parent)) if new.starts_with(&path) => {
 			let Some(name) = new.file_name() else {
 				return Ok(());
 			};
@@ -78,7 +78,7 @@ pub fn load(data: &[u8]) -> Result<(), Errno> {
 	for entry in cpio_parser {
 		let hdr = entry.get_hdr();
 
-		let mut parent_path = Path::new(entry.get_filename())?;
+		let parent_path = Path::new(entry.get_filename())?;
 		let Some(name) = parent_path.file_name() else {
 			continue;
 		};
@@ -106,7 +106,7 @@ pub fn load(data: &[u8]) -> Result<(), Errno> {
 			None => true,
 		};
 		if update {
-			update_parent(&parent_path, &mut stored_parent, false)?;
+			update_parent(parent_path, &mut stored_parent, false)?;
 		}
 
 		let parent_mutex = &stored_parent.as_ref().unwrap().1;

--- a/src/file/fs/initramfs/mod.rs
+++ b/src/file/fs/initramfs/mod.rs
@@ -10,6 +10,7 @@ use crate::file;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::file::FileContent;
 use crate::file::FileType;
@@ -34,15 +35,15 @@ fn update_parent(
 	// Get the parent
 	let result = match stored {
 		Some((path, file)) if new.starts_with(path) => {
-			let name = match new.file_name() {
-				Some(name) => name,
-				None => return Ok(()),
+			let Some(name) = new.file_name() else {
+				return Ok(());
 			};
+			let name = name.try_into()?;
 
 			let f = file.lock();
-			vfs::get_file_from_parent(&f, name.try_into()?, &AccessProfile::KERNEL, false)
+			vfs::get_file_from_parent(&f, name, &ResolutionSettings::kernel_nofollow())
 		}
-		Some(_) | None => vfs::get_file_from_path(new, &AccessProfile::KERNEL, false),
+		Some(_) | None => vfs::get_file_from_path(new, &ResolutionSettings::kernel_nofollow()),
 	};
 
 	match result {

--- a/src/file/fs/kernfs/mod.rs
+++ b/src/file/fs/kernfs/mod.rs
@@ -269,7 +269,7 @@ impl Filesystem for KernFS {
 		self.readonly
 	}
 
-	fn must_cache(&self) -> bool {
+	fn use_cache(&self) -> bool {
 		false
 	}
 

--- a/src/file/fs/kernfs/mod.rs
+++ b/src/file/fs/kernfs/mod.rs
@@ -274,6 +274,10 @@ impl Filesystem for KernFS {
 		false
 	}
 
+	fn get_root_inode(&self) -> INode {
+		ROOT_INODE
+	}
+
 	fn get_stat(&self, _io: &mut dyn IO) -> Result<Statfs, Errno> {
 		Ok(Statfs {
 			f_type: 0, // TODO
@@ -288,10 +292,6 @@ impl Filesystem for KernFS {
 			f_frsize: 0,
 			f_flags: 0,
 		})
-	}
-
-	fn get_root_inode(&self, _io: &mut dyn IO) -> Result<INode, Errno> {
-		Ok(ROOT_INODE)
 	}
 
 	fn get_inode(

--- a/src/file/fs/kernfs/mod.rs
+++ b/src/file/fs/kernfs/mod.rs
@@ -4,8 +4,8 @@ pub mod content;
 pub mod node;
 
 use crate::errno;
-use crate::errno::AllocError;
 use crate::errno::Errno;
+use crate::errno::{AllocError, EResult};
 use crate::file::fs::kernfs::node::DummyKernFSNode;
 use crate::file::fs::Filesystem;
 use crate::file::fs::Statfs;
@@ -416,7 +416,7 @@ impl Filesystem for KernFS {
 		_: &mut dyn IO,
 		parent_inode: INode,
 		name: &[u8],
-	) -> Result<u16, Errno> {
+	) -> EResult<(u16, INode)> {
 		if unlikely(self.readonly) {
 			return Err(errno!(EROFS));
 		}
@@ -466,7 +466,7 @@ impl Filesystem for KernFS {
 			oom::wrap(|| self.remove_node(inode).map_err(|_| AllocError));
 		}
 
-		Ok(links)
+		Ok((links, inode))
 	}
 
 	fn read_node(

--- a/src/file/fs/kernfs/mod.rs
+++ b/src/file/fs/kernfs/mod.rs
@@ -36,7 +36,8 @@ pub const ROOT_INODE: INode = 0;
 /// The maximum length of a name in the filesystem.
 const MAX_NAME_LEN: usize = 255;
 
-/// Structure representing a kernel file system.
+/// A kernel file system.
+#[derive(Debug)]
 pub struct KernFS {
 	/// The name of the filesystem.
 	name: String,

--- a/src/file/fs/kernfs/node.rs
+++ b/src/file/fs/kernfs/node.rs
@@ -14,9 +14,10 @@ use crate::time::unit::Timestamp;
 use crate::time::unit::TimestampScale;
 use crate::util::io::IO;
 use core::any::Any;
+use core::fmt::Debug;
 
 /// Trait representing a node in a kernfs.
-pub trait KernFSNode: Any + IO {
+pub trait KernFSNode: Any + Debug + IO {
 	/// Returns the number of hard links to the node.
 	fn get_hard_links_count(&self) -> u16 {
 		1
@@ -82,6 +83,7 @@ pub trait KernFSNode: Any + IO {
 /// This node doesn't implement regular files' content handling.
 ///
 /// Calling `read` or `write` on this structure does nothing.
+#[derive(Debug)]
 pub struct DummyKernFSNode {
 	/// The number of hard links to the node.
 	hard_links_count: u16,

--- a/src/file/fs/mod.rs
+++ b/src/file/fs/mod.rs
@@ -69,11 +69,10 @@ pub trait Filesystem: Any + Debug {
 	fn is_readonly(&self) -> bool;
 	/// Tells the kernel can cache the filesystem's files in memory.
 	fn use_cache(&self) -> bool;
+	/// Returns the root inode of the filesystem.
+	fn get_root_inode(&self) -> INode;
 	/// Returns statistics about the filesystem.
 	fn get_stat(&self, io: &mut dyn IO) -> EResult<Statfs>;
-
-	/// Returns the root inode of the filesystem.
-	fn get_root_inode(&self, io: &mut dyn IO) -> EResult<INode>;
 
 	/// Returns the inode of the file with name `name`, located in the directory
 	/// with inode `parent`.

--- a/src/file/fs/mod.rs
+++ b/src/file/fs/mod.rs
@@ -22,6 +22,7 @@ use crate::util::io::IO;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use core::any::Any;
+use core::fmt::Debug;
 
 /// This structure is used in the f_fsid field of statfs. It is currently
 /// unused.
@@ -61,7 +62,7 @@ pub struct Statfs {
 }
 
 /// Trait representing a filesystem.
-pub trait Filesystem: Any {
+pub trait Filesystem: Any + Debug {
 	/// Returns the name of the filesystem.
 	fn get_name(&self) -> &[u8];
 	/// Tells whether the filesystem is mounted in read-only.

--- a/src/file/fs/mod.rs
+++ b/src/file/fs/mod.rs
@@ -7,10 +7,10 @@ pub mod kernfs;
 pub mod procfs;
 pub mod tmp;
 
-use super::path::Path;
+use super::path::PathBuf;
 use super::File;
 use crate::errno;
-use crate::errno::Errno;
+use crate::errno::EResult;
 use crate::file::perm::Gid;
 use crate::file::perm::Uid;
 use crate::file::FileContent;
@@ -71,10 +71,10 @@ pub trait Filesystem: Any {
 	fn must_cache(&self) -> bool;
 
 	/// Returns statistics about the filesystem.
-	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno>;
+	fn get_stat(&self, io: &mut dyn IO) -> EResult<Statfs>;
 
 	/// Returns the root inode of the filesystem.
-	fn get_root_inode(&self, io: &mut dyn IO) -> Result<INode, Errno>;
+	fn get_root_inode(&self, io: &mut dyn IO) -> EResult<INode>;
 
 	/// Returns the inode of the file with name `name`, located in the directory
 	/// with inode `parent`.
@@ -86,12 +86,8 @@ pub trait Filesystem: Any {
 	/// - `name` is the name of the file.
 	///
 	/// If the parent is not a directory, the function returns an error.
-	fn get_inode(
-		&mut self,
-		io: &mut dyn IO,
-		parent: Option<INode>,
-		name: &[u8],
-	) -> Result<INode, Errno>;
+	fn get_inode(&mut self, io: &mut dyn IO, parent: Option<INode>, name: &[u8])
+		-> EResult<INode>;
 
 	/// Loads the file at inode `inode`.
 	///
@@ -99,7 +95,7 @@ pub trait Filesystem: Any {
 	/// - `io` is the IO interface.
 	/// - `inode` is the file's inode.
 	/// - `name` is the file's name.
-	fn load_file(&mut self, io: &mut dyn IO, inode: INode, name: String) -> Result<File, Errno>;
+	fn load_file(&mut self, io: &mut dyn IO, inode: INode, name: String) -> EResult<File>;
 
 	/// Adds a file to the filesystem at inode `inode`.
 	///
@@ -124,7 +120,7 @@ pub trait Filesystem: Any {
 		gid: Gid,
 		mode: Mode,
 		content: FileContent,
-	) -> Result<File, Errno>;
+	) -> EResult<File>;
 
 	/// Adds a hard link to the filesystem.
 	///
@@ -142,14 +138,14 @@ pub trait Filesystem: Any {
 		parent_inode: INode,
 		name: &[u8],
 		inode: INode,
-	) -> Result<(), Errno>;
+	) -> EResult<()>;
 
 	/// Updates the given inode.
 	///
 	/// Arguments:
 	/// - `io` is the IO interface.
 	/// - `file` the file structure containing the new values for the inode.
-	fn update_inode(&mut self, io: &mut dyn IO, file: &File) -> Result<(), Errno>;
+	fn update_inode(&mut self, io: &mut dyn IO, file: &File) -> EResult<()>;
 
 	/// Removes a file from the filesystem. If the links count of the inode
 	/// reaches zero, the inode is also removed.
@@ -160,12 +156,7 @@ pub trait Filesystem: Any {
 	/// - `name` is the file's name.
 	///
 	/// The function returns the number of hard links left on the inode.
-	fn remove_file(
-		&mut self,
-		io: &mut dyn IO,
-		parent_inode: INode,
-		name: &[u8],
-	) -> Result<u16, Errno>;
+	fn remove_file(&mut self, io: &mut dyn IO, parent_inode: INode, name: &[u8]) -> EResult<u16>;
 
 	/// Reads from the given inode `inode` into the buffer `buf`.
 	///
@@ -183,7 +174,7 @@ pub trait Filesystem: Any {
 		inode: INode,
 		off: u64,
 		buf: &mut [u8],
-	) -> Result<u64, Errno>;
+	) -> EResult<u64>;
 
 	/// Writes to the given inode `inode` from the buffer `buf`.
 	///
@@ -193,13 +184,7 @@ pub trait Filesystem: Any {
 	/// - `off` is the offset at which the data will be written in the node.
 	/// - `buf` is the buffer in which the data is the be written. The length of the buffer is the
 	/// number of bytes to read.
-	fn write_node(
-		&mut self,
-		io: &mut dyn IO,
-		inode: INode,
-		off: u64,
-		buf: &[u8],
-	) -> Result<(), Errno>;
+	fn write_node(&mut self, io: &mut dyn IO, inode: INode, off: u64, buf: &[u8]) -> EResult<()>;
 }
 
 /// Trait representing a filesystem type.
@@ -210,7 +195,7 @@ pub trait FilesystemType {
 	/// Tells whether the given IO interface has the current filesystem.
 	///
 	/// `io` is the IO interface.
-	fn detect(&self, io: &mut dyn IO) -> Result<bool, Errno>;
+	fn detect(&self, io: &mut dyn IO) -> EResult<bool>;
 
 	/// Creates a new instance of the filesystem to mount it.
 	///
@@ -221,16 +206,16 @@ pub trait FilesystemType {
 	fn load_filesystem(
 		&self,
 		io: &mut dyn IO,
-		mountpath: Path,
+		mountpath: PathBuf,
 		readonly: bool,
-	) -> Result<Arc<Mutex<dyn Filesystem>>, Errno>;
+	) -> EResult<Arc<Mutex<dyn Filesystem>>>;
 }
 
 /// The list of filesystem types.
 static FS_TYPES: Mutex<HashMap<String, Arc<dyn FilesystemType>>> = Mutex::new(HashMap::new());
 
 /// Registers a new filesystem type.
-pub fn register<T: 'static + FilesystemType>(fs_type: T) -> Result<(), Errno> {
+pub fn register<T: 'static + FilesystemType>(fs_type: T) -> EResult<()> {
 	let name = String::try_from(fs_type.get_name())?;
 
 	let mut container = FS_TYPES.lock();
@@ -254,7 +239,7 @@ pub fn get_type(name: &[u8]) -> Option<Arc<dyn FilesystemType>> {
 }
 
 /// Detects the filesystem type on the given IO interface `io`.
-pub fn detect(io: &mut dyn IO) -> Result<Arc<dyn FilesystemType>, Errno> {
+pub fn detect(io: &mut dyn IO) -> EResult<Arc<dyn FilesystemType>> {
 	let container = FS_TYPES.lock();
 
 	for (_, fs_type) in container.iter() {
@@ -269,7 +254,7 @@ pub fn detect(io: &mut dyn IO) -> Result<Arc<dyn FilesystemType>, Errno> {
 /// Registers the filesystems that are implemented inside of the kernel itself.
 ///
 /// This function must be called only once, at initialization.
-pub fn register_defaults() -> Result<(), Errno> {
+pub fn register_defaults() -> EResult<()> {
 	register(ext2::Ext2FsType {})?;
 	register(tmp::TmpFsType {})?;
 	register(procfs::ProcFsType {})?;

--- a/src/file/fs/mod.rs
+++ b/src/file/fs/mod.rs
@@ -153,8 +153,13 @@ pub trait Filesystem: Any {
 	/// - `parent_inode` is the parent file's inode.
 	/// - `name` is the file's name.
 	///
-	/// The function returns the number of hard links left on the inode.
-	fn remove_file(&mut self, io: &mut dyn IO, parent_inode: INode, name: &[u8]) -> EResult<u16>;
+	/// The function returns the number of hard links left on the inode and the inode's ID.
+	fn remove_file(
+		&mut self,
+		io: &mut dyn IO,
+		parent_inode: INode,
+		name: &[u8],
+	) -> EResult<(u16, INode)>;
 
 	/// Reads from the given inode `inode` into the buffer `buf`.
 	///
@@ -162,7 +167,7 @@ pub trait Filesystem: Any {
 	/// - `io` is the IO interface.
 	/// - `inode` is the file's inode.
 	/// - `off` is the offset from which the data will be read from the node.
-	/// - `buf` is the buffer in which the data is the be written. The length of the buffer is the
+	/// - `buf` is the buffer in which the data is to be written. The length of the buffer is the
 	/// number of bytes to read.
 	///
 	/// The function returns the number of bytes read.
@@ -180,8 +185,8 @@ pub trait Filesystem: Any {
 	/// - `io` is the IO interface.
 	/// - `inode` is the file's inode.
 	/// - `off` is the offset at which the data will be written in the node.
-	/// - `buf` is the buffer in which the data is the be written. The length of the buffer is the
-	/// number of bytes to read.
+	/// - `buf` is the buffer in which the data is to be read from. The length of the buffer is the
+	/// number of bytes to write.
 	fn write_node(&mut self, io: &mut dyn IO, inode: INode, off: u64, buf: &[u8]) -> EResult<()>;
 }
 

--- a/src/file/fs/mod.rs
+++ b/src/file/fs/mod.rs
@@ -64,12 +64,10 @@ pub struct Statfs {
 pub trait Filesystem: Any {
 	/// Returns the name of the filesystem.
 	fn get_name(&self) -> &[u8];
-
 	/// Tells whether the filesystem is mounted in read-only.
 	fn is_readonly(&self) -> bool;
-	/// Tells the kernel whether it must cache files.
-	fn must_cache(&self) -> bool;
-
+	/// Tells the kernel can cache the filesystem's files in memory.
+	fn use_cache(&self) -> bool;
 	/// Returns statistics about the filesystem.
 	fn get_stat(&self, io: &mut dyn IO) -> EResult<Statfs>;
 

--- a/src/file/fs/procfs/mem_info.rs
+++ b/src/file/fs/procfs/mem_info.rs
@@ -11,6 +11,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the meminfo node.
+#[derive(Debug)]
 pub struct MemInfo {}
 
 impl KernFSNode for MemInfo {

--- a/src/file/fs/procfs/mod.rs
+++ b/src/file/fs/procfs/mod.rs
@@ -17,7 +17,7 @@ use crate::errno::AllocError;
 use crate::errno::AllocResult;
 use crate::errno::Errno;
 use crate::file::fs::Statfs;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::perm::Gid;
 use crate::file::perm::Uid;
 use crate::file::DirEntry;
@@ -310,7 +310,7 @@ impl FilesystemType for ProcFsType {
 	fn load_filesystem(
 		&self,
 		_io: &mut dyn IO,
-		_mountpath: Path,
+		_mountpath: PathBuf,
 		readonly: bool,
 	) -> Result<Arc<Mutex<dyn Filesystem>>, Errno> {
 		Ok(Arc::new(Mutex::new(ProcFS::new(readonly)?))?)

--- a/src/file/fs/procfs/mod.rs
+++ b/src/file/fs/procfs/mod.rs
@@ -43,9 +43,10 @@ use sys_dir::SysDir;
 use uptime::Uptime;
 use version::Version;
 
-/// Structure representing the procfs.
+/// A procfs.
 ///
 /// On the inside, the procfs works using a kernfs.
+#[derive(Debug)]
 pub struct ProcFS {
 	/// The kernfs.
 	fs: KernFS,

--- a/src/file/fs/procfs/mod.rs
+++ b/src/file/fs/procfs/mod.rs
@@ -218,12 +218,12 @@ impl Filesystem for ProcFS {
 		self.fs.use_cache()
 	}
 
-	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {
-		self.fs.get_stat(io)
+	fn get_root_inode(&self) -> INode {
+		self.fs.get_root_inode()
 	}
 
-	fn get_root_inode(&self, io: &mut dyn IO) -> Result<INode, Errno> {
-		self.fs.get_root_inode(io)
+	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {
+		self.fs.get_stat(io)
 	}
 
 	fn get_inode(

--- a/src/file/fs/procfs/mod.rs
+++ b/src/file/fs/procfs/mod.rs
@@ -213,8 +213,8 @@ impl Filesystem for ProcFS {
 		self.fs.is_readonly()
 	}
 
-	fn must_cache(&self) -> bool {
-		self.fs.must_cache()
+	fn use_cache(&self) -> bool {
+		self.fs.use_cache()
 	}
 
 	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {

--- a/src/file/fs/procfs/mod.rs
+++ b/src/file/fs/procfs/mod.rs
@@ -13,9 +13,9 @@ use super::kernfs::node::DummyKernFSNode;
 use super::kernfs::KernFS;
 use super::Filesystem;
 use super::FilesystemType;
-use crate::errno::AllocError;
 use crate::errno::AllocResult;
 use crate::errno::Errno;
+use crate::errno::{AllocError, EResult};
 use crate::file::fs::Statfs;
 use crate::file::path::PathBuf;
 use crate::file::perm::Gid;
@@ -270,7 +270,7 @@ impl Filesystem for ProcFS {
 		_io: &mut dyn IO,
 		_parent_inode: INode,
 		_name: &[u8],
-	) -> Result<u16, Errno> {
+	) -> EResult<(u16, INode)> {
 		Err(errno!(EACCES))
 	}
 

--- a/src/file/fs/procfs/proc_dir/cmdline.rs
+++ b/src/file/fs/procfs/proc_dir/cmdline.rs
@@ -16,6 +16,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the cmdline node of the procfs.
+#[derive(Debug)]
 pub struct Cmdline {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/proc_dir/cwd.rs
+++ b/src/file/fs/procfs/proc_dir/cwd.rs
@@ -14,7 +14,8 @@ use crate::process::Process;
 use crate::util::io::IO;
 use crate::util::TryClone;
 
-/// Struture representing the `cwd` node.
+/// Structure representing the `cwd` node.
+#[derive(Debug)]
 pub struct Cwd {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/proc_dir/cwd.rs
+++ b/src/file/fs/procfs/proc_dir/cwd.rs
@@ -12,6 +12,7 @@ use crate::file::Mode;
 use crate::process::pid::Pid;
 use crate::process::Process;
 use crate::util::io::IO;
+use crate::util::TryClone;
 
 /// Struture representing the `cwd` node.
 pub struct Cwd {
@@ -44,7 +45,7 @@ impl KernFSNode for Cwd {
 		let content = Process::get_by_pid(self.pid)
 			.map(|mutex| {
 				let proc = mutex.lock();
-				crate::format!("{}", &*proc.cwd)
+				(&*proc.cwd).try_clone()
 			})
 			.transpose()?
 			.unwrap_or_default();

--- a/src/file/fs/procfs/proc_dir/cwd.rs
+++ b/src/file/fs/procfs/proc_dir/cwd.rs
@@ -45,7 +45,7 @@ impl KernFSNode for Cwd {
 		let content = Process::get_by_pid(self.pid)
 			.map(|mutex| {
 				let proc = mutex.lock();
-				(&*proc.cwd).try_clone()
+				proc.cwd.0.try_clone()
 			})
 			.transpose()?
 			.unwrap_or_default();

--- a/src/file/fs/procfs/proc_dir/exe.rs
+++ b/src/file/fs/procfs/proc_dir/exe.rs
@@ -14,7 +14,8 @@ use crate::process::Process;
 use crate::util::io::IO;
 use crate::util::TryClone;
 
-/// Struture representing the `exe` node.
+/// Structure representing the `exe` node.
+#[derive(Debug)]
 pub struct Exe {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/proc_dir/exe.rs
+++ b/src/file/fs/procfs/proc_dir/exe.rs
@@ -45,7 +45,7 @@ impl KernFSNode for Exe {
 		let content = Process::get_by_pid(self.pid)
 			.map(|mutex| {
 				let proc = mutex.lock();
-				(&*proc.exec_path).try_clone()
+				(*proc.exec_path).try_clone()
 			})
 			.transpose()?
 			.unwrap_or_default();

--- a/src/file/fs/procfs/proc_dir/exe.rs
+++ b/src/file/fs/procfs/proc_dir/exe.rs
@@ -12,6 +12,7 @@ use crate::file::Mode;
 use crate::process::pid::Pid;
 use crate::process::Process;
 use crate::util::io::IO;
+use crate::util::TryClone;
 
 /// Struture representing the `exe` node.
 pub struct Exe {
@@ -44,7 +45,7 @@ impl KernFSNode for Exe {
 		let content = Process::get_by_pid(self.pid)
 			.map(|mutex| {
 				let proc = mutex.lock();
-				crate::format!("{}", &*proc.exec_path)
+				(&*proc.exec_path).try_clone()
 			})
 			.transpose()?
 			.unwrap_or_default();

--- a/src/file/fs/procfs/proc_dir/mod.rs
+++ b/src/file/fs/procfs/proc_dir/mod.rs
@@ -33,6 +33,7 @@ use stat::Stat;
 use status::Status;
 
 /// Structure representing the directory of a process.
+#[derive(Debug)]
 pub struct ProcDir {
 	/// The PID of the process.
 	pid: Pid,

--- a/src/file/fs/procfs/proc_dir/mounts.rs
+++ b/src/file/fs/procfs/proc_dir/mounts.rs
@@ -69,11 +69,9 @@ impl IO for Mounts {
 			let flags = "TODO"; // TODO
 
 			let s = crate::format!(
-				"{} {} {} {} 0 0\n",
-				mp.get_source(),
-				mp.get_path(),
-				fs_type,
-				flags
+				"{source} {target} {fs_type} {flags} 0 0\n",
+				source = mp.get_source(),
+				target = mp.get_target_path(),
 			)?;
 			content.push_str(s)?;
 		}

--- a/src/file/fs/procfs/proc_dir/mounts.rs
+++ b/src/file/fs/procfs/proc_dir/mounts.rs
@@ -17,6 +17,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the mounts node of the procfs.
+#[derive(Debug)]
 pub struct Mounts {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/proc_dir/stat.rs
+++ b/src/file/fs/procfs/proc_dir/stat.rs
@@ -15,6 +15,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the stat node of the procfs.
+#[derive(Debug)]
 pub struct Stat {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/proc_dir/status.rs
+++ b/src/file/fs/procfs/proc_dir/status.rs
@@ -15,6 +15,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the status node of the procfs.
+#[derive(Debug)]
 pub struct Status {
 	/// The PID of the process.
 	pub pid: Pid,

--- a/src/file/fs/procfs/self_link.rs
+++ b/src/file/fs/procfs/self_link.rs
@@ -16,6 +16,7 @@ use crate::time::unit::Timestamp;
 use crate::util::io::IO;
 
 /// The `self` symlink.
+#[derive(Debug)]
 pub struct SelfNode {}
 
 impl KernFSNode for SelfNode {

--- a/src/file/fs/procfs/self_link.rs
+++ b/src/file/fs/procfs/self_link.rs
@@ -5,6 +5,7 @@ use crate::errno::EResult;
 use crate::errno::Errno;
 use crate::file::fs::kernfs::content::KernFSContent;
 use crate::file::fs::kernfs::node::KernFSNode;
+use crate::file::path::PathBuf;
 use crate::file::perm;
 use crate::file::perm::Gid;
 use crate::file::perm::Uid;
@@ -62,8 +63,8 @@ impl KernFSNode for SelfNode {
 
 	fn get_content(&mut self) -> EResult<KernFSContent<'_>> {
 		let pid = Process::current_assert().lock().pid;
-		let pid_string = crate::format!("{pid}")?;
-		Ok(FileContent::Link(pid_string).into())
+		let pid = PathBuf::try_from(crate::format!("{pid}")?)?;
+		Ok(FileContent::Link(pid).into())
 	}
 }
 

--- a/src/file/fs/procfs/sys_dir/kernel_dir/mod.rs
+++ b/src/file/fs/procfs/sys_dir/kernel_dir/mod.rs
@@ -20,6 +20,7 @@ use osrelease::OsRelease;
 
 // TODO Handle dropping
 /// Structure representing the `kernel` directory.
+#[derive(Debug)]
 pub struct KernelDir {
 	/// The content of the directory. This will always be a Directory variant.
 	content: FileContent,

--- a/src/file/fs/procfs/sys_dir/kernel_dir/osrelease.rs
+++ b/src/file/fs/procfs/sys_dir/kernel_dir/osrelease.rs
@@ -12,6 +12,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the `osrelease` node.
+#[derive(Debug)]
 pub struct OsRelease {}
 
 impl KernFSNode for OsRelease {

--- a/src/file/fs/procfs/sys_dir/mod.rs
+++ b/src/file/fs/procfs/sys_dir/mod.rs
@@ -21,6 +21,7 @@ use kernel_dir::KernelDir;
 
 // TODO Handle dropping
 /// Structure representing the `sys` directory.
+#[derive(Debug)]
 pub struct SysDir {
 	/// The content of the directory. This will always be a Directory variant.
 	content: FileContent,

--- a/src/file/fs/procfs/uptime.rs
+++ b/src/file/fs/procfs/uptime.rs
@@ -10,6 +10,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// The uptime node.
+#[derive(Debug)]
 pub struct Uptime {}
 
 impl KernFSNode for Uptime {

--- a/src/file/fs/procfs/version.rs
+++ b/src/file/fs/procfs/version.rs
@@ -9,6 +9,7 @@ use crate::util::io::IO;
 use core::cmp::min;
 
 /// Structure representing the version node.
+#[derive(Debug)]
 pub struct Version {}
 
 impl KernFSNode for Version {

--- a/src/file/fs/tmp/mod.rs
+++ b/src/file/fs/tmp/mod.rs
@@ -125,12 +125,12 @@ impl Filesystem for TmpFS {
 		self.fs.use_cache()
 	}
 
-	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {
-		self.fs.get_stat(io)
+	fn get_root_inode(&self) -> INode {
+		self.fs.get_root_inode()
 	}
 
-	fn get_root_inode(&self, io: &mut dyn IO) -> Result<INode, Errno> {
-		self.fs.get_root_inode(io)
+	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {
+		self.fs.get_stat(io)
 	}
 
 	fn get_inode(

--- a/src/file/fs/tmp/mod.rs
+++ b/src/file/fs/tmp/mod.rs
@@ -38,9 +38,10 @@ fn get_used_size<N: KernFSNode>(node: &N) -> usize {
 	size_of::<N>() + node.get_size() as usize
 }
 
-/// Structure representing the temporary file system.
+/// A temporary file system.
 ///
 /// On the inside, the tmpfs works using a kernfs.
+#[derive(Debug)]
 pub struct TmpFS {
 	/// The maximum amount of memory in bytes the filesystem can use.
 	max_size: usize,

--- a/src/file/fs/tmp/mod.rs
+++ b/src/file/fs/tmp/mod.rs
@@ -190,7 +190,7 @@ impl Filesystem for TmpFS {
 		io: &mut dyn IO,
 		parent_inode: INode,
 		name: &[u8],
-	) -> Result<u16, Errno> {
+	) -> EResult<(u16, INode)> {
 		// TODO Update fs's size
 		self.fs.remove_file(io, parent_inode, name)
 	}

--- a/src/file/fs/tmp/mod.rs
+++ b/src/file/fs/tmp/mod.rs
@@ -10,9 +10,10 @@ use super::kernfs::KernFS;
 use super::Filesystem;
 use super::FilesystemType;
 use crate::errno;
+use crate::errno::EResult;
 use crate::file::fs::kernfs::node::DummyKernFSNode;
 use crate::file::fs::Statfs;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::perm::Gid;
 use crate::file::perm::Uid;
 use crate::file::Errno;
@@ -224,16 +225,16 @@ impl FilesystemType for TmpFsType {
 		b"tmpfs"
 	}
 
-	fn detect(&self, _io: &mut dyn IO) -> Result<bool, Errno> {
+	fn detect(&self, _io: &mut dyn IO) -> EResult<bool> {
 		Ok(false)
 	}
 
 	fn load_filesystem(
 		&self,
 		_io: &mut dyn IO,
-		_mountpath: Path,
+		_mountpath: PathBuf,
 		readonly: bool,
-	) -> Result<Arc<Mutex<dyn Filesystem>>, Errno> {
+	) -> EResult<Arc<Mutex<dyn Filesystem>>> {
 		Ok(Arc::new(Mutex::new(TmpFS::new(
 			DEFAULT_MAX_SIZE,
 			readonly,

--- a/src/file/fs/tmp/mod.rs
+++ b/src/file/fs/tmp/mod.rs
@@ -120,8 +120,8 @@ impl Filesystem for TmpFS {
 		self.fs.is_readonly()
 	}
 
-	fn must_cache(&self) -> bool {
-		self.fs.must_cache()
+	fn use_cache(&self) -> bool {
+		self.fs.use_cache()
 	}
 
 	fn get_stat(&self, io: &mut dyn IO) -> Result<Statfs, Errno> {

--- a/src/file/fs/tmp/node.rs
+++ b/src/file/fs/tmp/node.rs
@@ -18,6 +18,7 @@ use core::cmp::max;
 use core::cmp::min;
 
 /// Structure representing a regular file node in the tmpfs.
+#[derive(Debug)]
 pub struct TmpFSRegular {
 	/// The number of hard links to the node.
 	hard_links_count: u16,

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -401,7 +401,7 @@ impl File {
 	pub fn get_path(&self) -> EResult<PathBuf> {
 		let mut parent_path = self.parent_path.try_clone()?;
 		if !self.name.is_empty() {
-			parent_path.join(Path::new(&self.name)?)?;
+			parent_path = parent_path.join(Path::new(&self.name)?)?;
 		}
 		Ok(parent_path)
 	}
@@ -716,7 +716,7 @@ impl File {
 	}
 
 	/// Closes the file, removing it if removal has been deferred.
-	pub fn close(mut self) -> EResult<()> {
+	pub fn close(&mut self) -> EResult<()> {
 		if let Some(deferred_remove) = self.deferred_remove.take() {
 			// No need to check permissions since they already have been checked before deferring
 			vfs::remove_file_unchecked(&deferred_remove.parent, &deferred_remove.name)?;

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -700,11 +700,10 @@ impl File {
 
 	/// Closes the file, removing it if removal has been deferred.
 	pub fn close(mut self) -> EResult<()> {
-		if !self.deferred_remove {
-			return Ok(());
+		if self.deferred_remove {
+			vfs::remove_file(&mut self, &AccessProfile::KERNEL)?;
+			self.removed = true;
 		}
-		vfs::remove_file(&mut self, &AccessProfile::KERNEL)?;
-		self.removed = true;
 		Ok(())
 	}
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -292,6 +292,15 @@ impl TryClone for FileContent {
 	}
 }
 
+/// Information to remove a file when all its handles are closed.
+#[derive(Debug)]
+pub struct DeferredRemove {
+	/// The location of the parent directory.
+	pub parent: FileLocation,
+	/// The name of the entry to remove.
+	pub name: String,
+}
+
 /// Structure representing a file.
 #[derive(Debug)]
 pub struct File {
@@ -327,11 +336,10 @@ pub struct File {
 	/// The content of the file.
 	content: FileContent,
 
-	/// Tells whether remove has been deferred for the file. If `true`, then the file will be
-	/// removed when the file is no longer used.
-	deferred_remove: bool,
-	/// Tells whether the file has been removed.
-	removed: bool,
+	/// If not `None`, the file will be removed when the last handle to it is closed.
+	///
+	/// This field contains all the information necessary to remove it.
+	deferred_remove: Option<DeferredRemove>,
 }
 
 impl File {
@@ -375,8 +383,7 @@ impl File {
 			location,
 			content,
 
-			deferred_remove: false,
-			removed: false,
+			deferred_remove: None,
 		})
 	}
 
@@ -428,6 +435,16 @@ impl File {
 	/// stored.
 	pub fn get_location(&self) -> &FileLocation {
 		&self.location
+	}
+
+	/// Returns the mountpoint located at this file, if any.
+	pub fn as_mountpoint(&self) -> Option<Arc<Mutex<MountPoint>>> {
+		mountpoint::from_location(&self.location)
+	}
+
+	/// Tells whether there is a mountpoint on the file.
+	pub fn is_mountpoint(&self) -> bool {
+		self.as_mountpoint().is_some()
 	}
 
 	/// Returns the number of hard links.
@@ -694,28 +711,24 @@ impl File {
 	}
 
 	/// Defers removal of the file, meaning the file will be removed when closed.
-	pub fn defer_remove(&mut self) {
-		self.deferred_remove = true;
+	pub fn defer_remove(&mut self, info: DeferredRemove) {
+		self.deferred_remove = Some(info);
 	}
 
 	/// Closes the file, removing it if removal has been deferred.
 	pub fn close(mut self) -> EResult<()> {
-		if self.deferred_remove {
-			vfs::remove_file(&mut self, &AccessProfile::KERNEL)?;
-			self.removed = true;
+		if let Some(deferred_remove) = self.deferred_remove.take() {
+			// No need to check permissions since they already have been checked before deferring
+			vfs::remove_file_unchecked(&deferred_remove.parent, &deferred_remove.name)?;
 		}
 		Ok(())
 	}
 }
 
 impl Drop for File {
-	/// This function is used in case removal of the file has been deferred, but `close` has not
-	/// been called.
 	fn drop(&mut self) {
-		if !self.deferred_remove || self.removed {
-			return;
-		}
-		let _ = vfs::remove_file(self, &AccessProfile::KERNEL);
+		// TODO: kernel log on error?
+		let _ = self.close();
 	}
 }
 

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -176,8 +176,8 @@ pub enum FileLocation {
 }
 
 impl FileLocation {
-	/// Returns the location of the VFS's root.
-	pub const fn root() -> Self {
+	/// Dummy location, to be used by the root mountpoint.
+	pub const fn dummy() -> Self {
 		Self::Filesystem {
 			mountpoint_id: 0,
 			inode: 0,
@@ -931,8 +931,13 @@ pub(crate) fn init(root: Option<(u32, u32)>) -> Result<(), Errno> {
 		},
 		None => MountSource::NoDev(String::try_from(b"tmpfs")?),
 	};
-	let mp_id = mountpoint::create(mount_source, None, 0, PathBuf::root(), FileLocation::root())?;
-	assert_eq!(mp_id, FileLocation::root().get_mountpoint_id().unwrap());
+	mountpoint::create(
+		mount_source,
+		None,
+		0,
+		PathBuf::root(),
+		FileLocation::dummy(),
+	)?;
 
 	Ok(())
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -176,6 +176,14 @@ pub enum FileLocation {
 }
 
 impl FileLocation {
+	/// Returns the location of the VFS's root.
+	pub const fn root() -> Self {
+		Self::Filesystem {
+			mountpoint_id: 0,
+			inode: 0,
+		}
+	}
+
 	/// Returns the ID of the mountpoint.
 	pub fn get_mountpoint_id(&self) -> Option<u32> {
 		match self {
@@ -906,14 +914,12 @@ pub(crate) fn init(root: Option<(u32, u32)>) -> Result<(), Errno> {
 	let mount_source = match root {
 		Some((major, minor)) => MountSource::Device {
 			dev_type: DeviceType::Block,
-
 			major,
 			minor,
 		},
-
 		None => MountSource::NoDev(String::try_from(b"tmpfs")?),
 	};
-	mountpoint::create(mount_source, None, 0, PathBuf::root())?;
+	mountpoint::create(mount_source, None, 0, PathBuf::root(), FileLocation::root())?;
 
 	Ok(())
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -194,7 +194,7 @@ impl FileLocation {
 		}
 	}
 
-	/// Returns the mountpoint.
+	/// Returns the mountpoint on which the file is located.
 	pub fn get_mountpoint(&self) -> Option<Arc<Mutex<MountPoint>>> {
 		mountpoint::from_id(self.get_mountpoint_id()?)
 	}
@@ -931,7 +931,8 @@ pub(crate) fn init(root: Option<(u32, u32)>) -> Result<(), Errno> {
 		},
 		None => MountSource::NoDev(String::try_from(b"tmpfs")?),
 	};
-	mountpoint::create(mount_source, None, 0, PathBuf::root(), FileLocation::root())?;
+	let mp_id = mountpoint::create(mount_source, None, 0, PathBuf::root(), FileLocation::root())?;
+	assert_eq!(mp_id, FileLocation::root().get_mountpoint_id().unwrap());
 
 	Ok(())
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -27,6 +27,7 @@ use crate::errno::Errno;
 use crate::file::buffer::pipe::PipeBuffer;
 use crate::file::buffer::socket::Socket;
 use crate::file::fs::Filesystem;
+use crate::file::path::PathBuf;
 use crate::file::perm::Gid;
 use crate::file::perm::Uid;
 use crate::process::mem_space::MemSpace;
@@ -291,7 +292,7 @@ pub struct File {
 	/// The name of the file.
 	name: String,
 	/// The path of the file's parent.
-	parent_path: Path,
+	parent_path: PathBuf,
 
 	/// The number of hard links associated with the file.
 	hard_links_count: u16,
@@ -350,7 +351,7 @@ impl File {
 
 		Ok(Self {
 			name,
-			parent_path: Path::root(),
+			parent_path: PathBuf::root(),
 
 			hard_links_count: 1,
 
@@ -384,19 +385,18 @@ impl File {
 	}
 
 	/// Returns the absolute path of the file.
-	pub fn get_path(&self) -> Result<Path, Errno> {
+	pub fn get_path(&self) -> EResult<PathBuf> {
 		let mut parent_path = self.parent_path.try_clone()?;
 		if !self.name.is_empty() {
-			parent_path.push(self.name.try_clone()?)?;
+			parent_path.join(Path::new(&self.name)?)?;
 		}
-
 		Ok(parent_path)
 	}
 
 	/// Sets the file's parent path.
 	///
 	/// If the path isn't absolute, the behaviour is undefined.
-	pub fn set_parent_path(&mut self, parent_path: Path) {
+	pub fn set_parent_path(&mut self, parent_path: PathBuf) {
 		self.parent_path = parent_path;
 	}
 
@@ -915,7 +915,7 @@ pub(crate) fn init(root: Option<(u32, u32)>) -> Result<(), Errno> {
 
 		None => MountSource::NoDev(String::try_from(b"tmpfs")?),
 	};
-	mountpoint::create(mount_source, None, 0, Path::root())?;
+	mountpoint::create(mount_source, None, 0, PathBuf::root())?;
 
 	Ok(())
 }

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -182,7 +182,6 @@ impl FileLocation {
 			Self::Filesystem {
 				mountpoint_id, ..
 			} => Some(*mountpoint_id),
-
 			_ => None,
 		}
 	}
@@ -198,7 +197,6 @@ impl FileLocation {
 			Self::Filesystem {
 				inode, ..
 			} => *inode,
-
 			Self::Virtual {
 				id,
 			} => *id as _,
@@ -226,7 +224,7 @@ pub enum FileContent {
 	/// is the entry itself.
 	Directory(HashMap<String, DirEntry>),
 	/// The file is a link. The data is the link's target.
-	Link(String),
+	Link(PathBuf),
 	/// The file is a FIFO.
 	Fifo,
 	/// The file is a socket.

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -3,14 +3,14 @@
 use super::fs;
 use super::fs::Filesystem;
 use super::fs::FilesystemType;
-use super::path::Path;
+use super::path::{Path, PathBuf};
 use super::vfs;
 use super::FileContent;
 use crate::device;
 use crate::device::DeviceID;
 use crate::device::DeviceType;
-use crate::errno::AllocResult;
 use crate::errno::Errno;
+use crate::errno::{AllocResult, EResult};
 use crate::file::perm::AccessProfile;
 use crate::util::container::hashmap::HashMap;
 use crate::util::container::string::String;
@@ -77,17 +77,12 @@ impl MountSource {
 	///
 	/// The string `string` might be either a kernfs name, a relative path or an
 	/// absolute path.
-	///
-	/// `cwd` is the current working directory.
-	pub fn from_str(string: &[u8], cwd: Path) -> Result<Self, Errno> {
-		let path = Path::from_str(string, true)?;
-		let path = cwd.concat(&path)?;
-
+	pub fn from_str(string: &[u8]) -> EResult<Self> {
+		let path = Path::new(string)?;
 		let result = vfs::get_file_from_path(&path, &AccessProfile::KERNEL, true);
 		match result {
 			Ok(file_mutex) => {
 				let file = file_mutex.lock();
-
 				match file.get_content() {
 					FileContent::BlockDevice {
 						major,
@@ -112,9 +107,7 @@ impl MountSource {
 					_ => Err(errno!(EINVAL)),
 				}
 			}
-
 			Err(err) if err == errno!(ENOENT) => Ok(Self::NoDev(String::try_from(string)?)),
-
 			Err(err) => Err(err),
 		}
 	}
@@ -192,7 +185,7 @@ static FILESYSTEMS: Mutex<HashMap<MountSource, LoadedFS>> = Mutex::new(HashMap::
 /// Arguments:
 /// - `source` is the source of the mountpoint.
 /// - `fs_type` is the filesystem type. If `None`, the function tries to detect it
-/// automaticaly.
+/// automatically.
 /// - `path` is the path to the directory on which the filesystem is mounted.
 /// - `readonly` tells whether the filesystem is mount in readonly.
 ///
@@ -200,7 +193,7 @@ static FILESYSTEMS: Mutex<HashMap<MountSource, LoadedFS>> = Mutex::new(HashMap::
 fn load_fs(
 	source: MountSource,
 	fs_type: Option<Arc<dyn FilesystemType>>,
-	path: Path,
+	path: PathBuf,
 	readonly: bool,
 ) -> Result<Arc<Mutex<dyn Filesystem>>, Errno> {
 	// Getting the I/O interface
@@ -210,7 +203,6 @@ fn load_fs(
 	// Getting the filesystem type
 	let fs_type = match fs_type {
 		Some(fs_type) => fs_type,
-
 		None => match source {
 			MountSource::NoDev(ref name) => fs::get_type(name).ok_or_else(|| errno!(ENODEV))?,
 			_ => fs::detect(&mut *io)?,
@@ -218,7 +210,7 @@ fn load_fs(
 	};
 	let fs = fs_type.load_filesystem(&mut *io, path, readonly)?;
 
-	// Inserting new filesystem into filesystems list
+	// Insert new filesystem into filesystems list
 	let mut container = FILESYSTEMS.lock();
 	container.insert(
 		source,
@@ -273,7 +265,7 @@ fn drop_fs(source: &MountSource) {
 	}
 }
 
-/// Structure representing a mount point.
+/// A mount point, allowing to attach a filesystem to a directory on the VFS.
 pub struct MountPoint {
 	/// The ID of the mountpoint.
 	id: u32,
@@ -281,7 +273,7 @@ pub struct MountPoint {
 	/// Mount flags.
 	flags: u32,
 	/// The path to the mount directory.
-	path: Path,
+	path: PathBuf,
 
 	/// The source of the mountpoint.
 	source: MountSource,
@@ -306,7 +298,7 @@ impl MountPoint {
 		source: MountSource,
 		fs_type: Option<Arc<dyn FilesystemType>>,
 		flags: u32,
-		path: Path,
+		path: PathBuf,
 	) -> Result<Self, Errno> {
 		// Tells whether the filesystem will be mounted in read-only
 		let readonly = flags & FLAG_RDONLY != 0;
@@ -314,7 +306,6 @@ impl MountPoint {
 		let fs_mutex = match get_fs_(&source, true) {
 			// Filesystem exists, do nothing
 			Some(fs) => fs,
-
 			// Filesystem doesn't exist, load it
 			None => load_fs(source.try_clone()?, fs_type, path.try_clone()?, readonly)?,
 		};
@@ -384,7 +375,7 @@ impl Drop for MountPoint {
 /// The list of mountpoints with their respective ID.
 pub static MOUNT_POINTS: Mutex<HashMap<u32, Arc<Mutex<MountPoint>>>> = Mutex::new(HashMap::new());
 /// A map from mountpoint paths to mountpoint IDs.
-pub static PATH_TO_ID: Mutex<HashMap<Path, u32>> = Mutex::new(HashMap::new());
+pub static PATH_TO_ID: Mutex<HashMap<PathBuf, u32>> = Mutex::new(HashMap::new());
 
 /// Creates a new mountpoint.
 ///
@@ -392,15 +383,15 @@ pub static PATH_TO_ID: Mutex<HashMap<Path, u32>> = Mutex::new(HashMap::new());
 ///
 /// Arguments:
 /// - `source` is the source of the mountpoint.
-/// - `fs_type` is the filesystem type. If `None`, the function tries to detect it automaticaly.
+/// - `fs_type` is the filesystem type. If `None`, the function tries to detect it automatically.
 /// - `flags` are the mount flags.
 /// - `path` is the path on which the filesystem is to be mounted.
 pub fn create(
 	source: MountSource,
 	fs_type: Option<Arc<dyn FilesystemType>>,
 	flags: u32,
-	path: Path,
-) -> Result<Arc<Mutex<MountPoint>>, Errno> {
+	path: PathBuf,
+) -> EResult<Arc<Mutex<MountPoint>>> {
 	// TODO clean
 	// PATH_TO_ID is locked first and during the whole function to prevent a race condition between
 	// the locks of MOUNT_POINTS
@@ -429,7 +420,6 @@ pub fn create(
 	// Insertion
 	{
 		let mut mount_points = MOUNT_POINTS.lock();
-
 		mount_points.insert(id, mountpoint.clone())?;
 		if let Err(e) = path_to_id.insert(path, id) {
 			mount_points.remove(&id);
@@ -442,12 +432,12 @@ pub fn create(
 
 /// Removes the mountpoint at the given path `path`.
 ///
-/// Data is sychronized to the associated storage device, if any, before removing the mountpoint.
+/// Data is synchronized to the associated storage device, if any, before removing the mountpoint.
 ///
 /// If the mountpoint doesn't exist, the function returns `EINVAL`.
 ///
 /// If the mountpoint is busy, the function returns `EBUSY`.
-pub fn remove(path: &Path) -> Result<(), Errno> {
+pub fn remove(path: &Path) -> EResult<()> {
 	let mut path_to_id = PATH_TO_ID.lock();
 	let mut mount_points = MOUNT_POINTS.lock();
 
@@ -465,31 +455,27 @@ pub fn remove(path: &Path) -> Result<(), Errno> {
 	Ok(())
 }
 
+// TODO cleanup
 /// Returns the deepest mountpoint in the path `path`.
 ///
 /// If no mountpoint is in the path, the function returns `None`.
 pub fn get_deepest(path: &Path) -> Option<Arc<Mutex<MountPoint>>> {
 	let container = MOUNT_POINTS.lock();
-
 	let mut max: Option<Arc<Mutex<MountPoint>>> = None;
 	for (_, mp) in container.iter() {
 		let mp_guard = mp.lock();
 		let mount_path = mp_guard.get_path();
-
 		if let Some(max) = max.as_mut() {
 			let max = max.lock();
 			let max_path = max.get_path();
-
-			if max_path.get_elements_count() >= mount_path.get_elements_count() {
+			if max_path.components().count() >= mount_path.components().count() {
 				continue;
 			}
 		}
-
-		if path.begins_with(mount_path) {
+		if path.starts_with(mount_path) {
 			max = Some(mp.clone());
 		}
 	}
-
 	max
 }
 

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -10,7 +10,7 @@ use crate::device;
 use crate::device::DeviceID;
 use crate::device::DeviceType;
 use crate::errno::{AllocResult, EResult};
-use crate::file::perm::AccessProfile;
+use crate::file::vfs::ResolutionSettings;
 use crate::util::container::hashmap::HashMap;
 use crate::util::container::string::String;
 use crate::util::io::DummyIO;
@@ -76,7 +76,7 @@ impl MountSource {
 	/// absolute path.
 	pub fn from_str(string: &[u8]) -> EResult<Self> {
 		let path = Path::new(string)?;
-		let result = vfs::get_file_from_path(&path, &AccessProfile::KERNEL, true);
+		let result = vfs::get_file_from_path(&path, &ResolutionSettings::default());
 		match result {
 			Ok(file_mutex) => {
 				let file = file_mutex.lock();

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -9,6 +9,7 @@ use super::{fs, FileLocation};
 use crate::device;
 use crate::device::DeviceID;
 use crate::device::DeviceType;
+use crate::errno;
 use crate::errno::{AllocResult, EResult};
 use crate::file::vfs::ResolutionSettings;
 use crate::util::container::hashmap::HashMap;
@@ -369,7 +370,7 @@ pub static LOC_TO_ID: Mutex<HashMap<FileLocation, u32>> = Mutex::new(HashMap::ne
 
 /// Creates a new mountpoint.
 ///
-/// If a mountpoint is already present at the same path, the function fails with [`EINVAL`].
+/// If a mountpoint is already present at the same path, the function fails with [`errno::EINVAL`].
 ///
 /// Arguments:
 /// - `source` is the source of the mountpoint.
@@ -432,9 +433,9 @@ pub fn create(
 ///
 /// Data is synchronized to the associated storage device, if any, before removing the mountpoint.
 ///
-/// If the mountpoint doesn't exist, the function returns [`EINVAL`].
+/// If the mountpoint doesn't exist, the function returns [`errno::EINVAL`].
 ///
-/// If the mountpoint is busy, the function returns [`EBUSY`].
+/// If the mountpoint is busy, the function returns [`errno::EBUSY`].
 pub fn remove(target_location: &FileLocation) -> EResult<()> {
 	let mut loc_to_id = LOC_TO_ID.lock();
 	let mut mount_points = MOUNT_POINTS.lock();

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -76,7 +76,7 @@ impl MountSource {
 	/// absolute path.
 	pub fn from_str(string: &[u8]) -> EResult<Self> {
 		let path = Path::new(string)?;
-		let result = vfs::get_file_from_path(&path, &ResolutionSettings::default());
+		let result = vfs::get_file_from_path(&path, &ResolutionSettings::kernel_follow());
 		match result {
 			Ok(file_mutex) => {
 				let file = file_mutex.lock();

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -1,15 +1,14 @@
 //! A mount point is a directory in which a filesystem is mounted.
 
-use super::fs;
 use super::fs::Filesystem;
 use super::fs::FilesystemType;
 use super::path::{Path, PathBuf};
 use super::vfs;
 use super::FileContent;
+use super::{fs, FileLocation};
 use crate::device;
 use crate::device::DeviceID;
 use crate::device::DeviceType;
-use crate::errno::Errno;
 use crate::errno::{AllocResult, EResult};
 use crate::file::perm::AccessProfile;
 use crate::util::container::hashmap::HashMap;
@@ -19,7 +18,6 @@ use crate::util::io::IO;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use crate::util::TryClone;
-use core::cmp::max;
 use core::fmt;
 
 /// Permits mandatory locking on files.
@@ -58,7 +56,6 @@ pub enum MountSource {
 	Device {
 		/// The device type.
 		dev_type: DeviceType,
-
 		/// The major number.
 		major: u32,
 		/// The minor number.
@@ -89,7 +86,6 @@ impl MountSource {
 						minor,
 					} => Ok(Self::Device {
 						dev_type: DeviceType::Block,
-
 						major: *major,
 						minor: *minor,
 					}),
@@ -99,7 +95,6 @@ impl MountSource {
 						minor,
 					} => Ok(Self::Device {
 						dev_type: DeviceType::Char,
-
 						major: *major,
 						minor: *minor,
 					}),
@@ -113,11 +108,10 @@ impl MountSource {
 	}
 
 	/// Returns the IO interface for the mount source.
-	pub fn get_io(&self) -> Result<Arc<Mutex<dyn IO>>, Errno> {
+	pub fn get_io(&self) -> EResult<Arc<Mutex<dyn IO>>> {
 		match self {
 			Self::Device {
 				dev_type,
-
 				major,
 				minor,
 			} => {
@@ -158,12 +152,11 @@ impl fmt::Display for MountSource {
 		match self {
 			Self::Device {
 				dev_type,
-
 				major,
 				minor,
-			} => write!(fmt, "{}.{}.{}", dev_type, major, minor),
+			} => write!(fmt, "dev({dev_type}:{major}:{minor})"),
 
-			Self::NoDev(name) => write!(fmt, "{}", name),
+			Self::NoDev(name) => write!(fmt, "{name}"),
 		}
 	}
 }
@@ -195,12 +188,12 @@ fn load_fs(
 	fs_type: Option<Arc<dyn FilesystemType>>,
 	path: PathBuf,
 	readonly: bool,
-) -> Result<Arc<Mutex<dyn Filesystem>>, Errno> {
-	// Getting the I/O interface
+) -> EResult<Arc<Mutex<dyn Filesystem>>> {
+	// Get the I/O interface
 	let io_mutex = source.get_io()?;
 	let mut io = io_mutex.lock();
 
-	// Getting the filesystem type
+	// Get the filesystem type
 	let fs_type = match fs_type {
 		Some(fs_type) => fs_type,
 		None => match source {
@@ -226,17 +219,16 @@ fn load_fs(
 
 /// Returns the loaded filesystem with the given source `source`.
 ///
-/// `take` tells whether the function increments the references count.
+/// `acquire` tells whether the function increments the references count.
 ///
 /// If the filesystem isn't loaded, the function returns `None`.
-fn get_fs_(source: &MountSource, take: bool) -> Option<Arc<Mutex<dyn Filesystem>>> {
+fn get_fs_impl(source: &MountSource, acquire: bool) -> Option<Arc<Mutex<dyn Filesystem>>> {
 	let mut container = FILESYSTEMS.lock();
-
 	let fs = container.get_mut(source)?;
-	if take {
+	// Increment the number of references if required
+	if acquire {
 		fs.ref_count += 1;
 	}
-
 	Some(fs.fs.clone())
 }
 
@@ -244,36 +236,15 @@ fn get_fs_(source: &MountSource, take: bool) -> Option<Arc<Mutex<dyn Filesystem>
 ///
 /// If the filesystem isn't loaded, the function returns `None`.
 pub fn get_fs(source: &MountSource) -> Option<Arc<Mutex<dyn Filesystem>>> {
-	get_fs_(source, false)
-}
-
-/// Drops a reference to the filesystem with the given source `source`.
-///
-/// If no reference on the filesystem is left, the function unloads it.
-///
-/// If the filesystem doesn't exist, the function does nothing.
-fn drop_fs(source: &MountSource) {
-	let mut container = FILESYSTEMS.lock();
-
-	if let Some(fs) = container.get_mut(source) {
-		fs.ref_count -= 1;
-
-		// If no reference left, drop
-		if fs.ref_count == 0 {
-			container.remove(source);
-		}
-	}
+	get_fs_impl(source, false)
 }
 
 /// A mount point, allowing to attach a filesystem to a directory on the VFS.
 pub struct MountPoint {
 	/// The ID of the mountpoint.
 	id: u32,
-
 	/// Mount flags.
 	flags: u32,
-	/// The path to the mount directory.
-	path: PathBuf,
 
 	/// The source of the mountpoint.
 	source: MountSource,
@@ -281,6 +252,11 @@ pub struct MountPoint {
 	fs: Arc<Mutex<dyn Filesystem>>,
 	/// The name of the filesystem's type.
 	fs_type_name: String,
+
+	/// The path to the mount directory.
+	target_path: PathBuf,
+	/// The location of the mount directory on the parent filesystem.
+	target_location: FileLocation,
 }
 
 impl MountPoint {
@@ -290,42 +266,44 @@ impl MountPoint {
 	/// - `id` is the ID of the mountpoint.
 	/// - `source` is the source of the mountpoint.
 	/// - `fs_type` is the filesystem type. If `None`, the function tries to detect it
-	/// automaticaly.
+	/// automatically.
 	/// - `flags` are the mount flags.
-	/// - `path` is the path on which the filesystem is to be mounted.
+	/// - `target_path` is the path to the mount directory.
+	/// - `target_location` is the location of the mount directory on the parent filesystem.
 	fn new(
 		id: u32,
 		source: MountSource,
 		fs_type: Option<Arc<dyn FilesystemType>>,
 		flags: u32,
-		path: PathBuf,
-	) -> Result<Self, Errno> {
-		// Tells whether the filesystem will be mounted in read-only
+		target_path: PathBuf,
+		target_location: FileLocation,
+	) -> EResult<Self> {
+		// Tells whether the filesystem will be mounted as read-only
 		let readonly = flags & FLAG_RDONLY != 0;
 
-		let fs_mutex = match get_fs_(&source, true) {
+		let fs = match get_fs_impl(&source, true) {
 			// Filesystem exists, do nothing
 			Some(fs) => fs,
 			// Filesystem doesn't exist, load it
-			None => load_fs(source.try_clone()?, fs_type, path.try_clone()?, readonly)?,
+			None => load_fs(
+				source.try_clone()?,
+				fs_type,
+				target_path.try_clone()?,
+				readonly,
+			)?,
 		};
-
-		// TODO Increment number of references to the filesystem
-
-		let fs_type_name = {
-			let fs = fs_mutex.lock();
-			String::try_from(fs.get_name())?
-		};
+		let fs_type_name = String::try_from(fs.lock().get_name())?;
 
 		Ok(Self {
 			id,
-
 			flags,
-			path,
 
 			source,
-			fs: fs_mutex,
+			fs,
 			fs_type_name,
+
+			target_path,
+			target_location,
 		})
 	}
 
@@ -339,14 +317,9 @@ impl MountPoint {
 		self.flags
 	}
 
-	/// Tells whether the mountpoint's is mounted in read-only.
+	/// Tells whether the mountpoint's is mounted as read-only.
 	pub fn is_readonly(&self) -> bool {
 		self.flags & FLAG_RDONLY != 0
-	}
-
-	/// Returns a reference to the path where the filesystem is mounted.
-	pub fn get_path(&self) -> &Path {
-		&self.path
 	}
 
 	/// Returns the source of the mountpoint.
@@ -354,8 +327,7 @@ impl MountPoint {
 		&self.source
 	}
 
-	/// Returns a mutable reference to the filesystem associated with the
-	/// mountpoint.
+	/// Returns the filesystem associated with the mountpoint.
 	pub fn get_filesystem(&self) -> Arc<Mutex<dyn Filesystem>> {
 		self.fs.clone()
 	}
@@ -364,49 +336,74 @@ impl MountPoint {
 	pub fn get_filesystem_type(&self) -> &String {
 		&self.fs_type_name
 	}
+
+	/// Returns a reference to the path where the filesystem is mounted.
+	pub fn get_target_path(&self) -> &Path {
+		&self.target_path
+	}
+
+	/// Returns a reference to the location of the mount directory on the parent filesystem.
+	pub fn get_target_location(&self) -> &FileLocation {
+		&self.target_location
+	}
 }
 
 impl Drop for MountPoint {
 	fn drop(&mut self) {
-		drop_fs(&self.source);
+		// Decrement the number of references to the filesystem
+		let mut container = FILESYSTEMS.lock();
+		if let Some(fs) = container.get_mut(&self.source) {
+			fs.ref_count -= 1;
+			// If no reference left, drop
+			if fs.ref_count == 0 {
+				container.remove(&self.source);
+			}
+		}
 	}
 }
 
 /// The list of mountpoints with their respective ID.
 pub static MOUNT_POINTS: Mutex<HashMap<u32, Arc<Mutex<MountPoint>>>> = Mutex::new(HashMap::new());
-/// A map from mountpoint paths to mountpoint IDs.
-pub static PATH_TO_ID: Mutex<HashMap<PathBuf, u32>> = Mutex::new(HashMap::new());
+/// A map from mount locations to mountpoint IDs.
+pub static LOC_TO_ID: Mutex<HashMap<FileLocation, u32>> = Mutex::new(HashMap::new());
 
 /// Creates a new mountpoint.
 ///
-/// If a mountpoint is already present at the same path, the function fails.
+/// If a mountpoint is already present at the same path, the function fails with [`EINVAL`].
 ///
 /// Arguments:
 /// - `source` is the source of the mountpoint.
 /// - `fs_type` is the filesystem type. If `None`, the function tries to detect it automatically.
 /// - `flags` are the mount flags.
-/// - `path` is the path on which the filesystem is to be mounted.
+/// - `target_path` is the path on which the filesystem is to be mounted.
+/// - `target_location` is the location on which the filesystem is to be mounted on the parent
+///   filesystem.
 pub fn create(
 	source: MountSource,
 	fs_type: Option<Arc<dyn FilesystemType>>,
 	flags: u32,
-	path: PathBuf,
+	target_path: PathBuf,
+	target_location: FileLocation,
 ) -> EResult<Arc<Mutex<MountPoint>>> {
 	// TODO clean
 	// PATH_TO_ID is locked first and during the whole function to prevent a race condition between
 	// the locks of MOUNT_POINTS
-	let mut path_to_id = PATH_TO_ID.lock();
+	let mut path_to_id = LOC_TO_ID.lock();
+	// If a mountpoint is already present at this location, error
+	if path_to_id.get(&target_location).is_some() {
+		return Err(errno!(EINVAL));
+	}
 
-	// TODO clean
+	// TODO improve
 	// ID allocation
 	let id = {
-		let mut id = 0;
-
-		for (i, _) in MOUNT_POINTS.lock().iter() {
-			id = max(*i, id);
-		}
-
-		id + 1
+		MOUNT_POINTS
+			.lock()
+			.iter()
+			.map(|(i, _)| *i)
+			.max()
+			.unwrap_or(0)
+			+ 1
 	};
 
 	let mountpoint = Arc::new(Mutex::new(MountPoint::new(
@@ -414,14 +411,15 @@ pub fn create(
 		source,
 		fs_type,
 		flags,
-		path.try_clone()?,
+		target_path,
+		target_location.clone(),
 	)?))?;
 
 	// Insertion
 	{
 		let mut mount_points = MOUNT_POINTS.lock();
 		mount_points.insert(id, mountpoint.clone())?;
-		if let Err(e) = path_to_id.insert(path, id) {
+		if let Err(e) = path_to_id.insert(target_location, id) {
 			mount_points.remove(&id);
 			return Err(e.into());
 		}
@@ -430,18 +428,18 @@ pub fn create(
 	Ok(mountpoint)
 }
 
-/// Removes the mountpoint at the given path `path`.
+/// Removes the mountpoint at the given `target_location`.
 ///
 /// Data is synchronized to the associated storage device, if any, before removing the mountpoint.
 ///
-/// If the mountpoint doesn't exist, the function returns `EINVAL`.
+/// If the mountpoint doesn't exist, the function returns [`EINVAL`].
 ///
-/// If the mountpoint is busy, the function returns `EBUSY`.
-pub fn remove(path: &Path) -> EResult<()> {
-	let mut path_to_id = PATH_TO_ID.lock();
+/// If the mountpoint is busy, the function returns [`EBUSY`].
+pub fn remove(target_location: &FileLocation) -> EResult<()> {
+	let mut loc_to_id = LOC_TO_ID.lock();
 	let mut mount_points = MOUNT_POINTS.lock();
 
-	let id = *path_to_id.get(path).ok_or(errno!(EINVAL))?;
+	let id = *loc_to_id.get(target_location).ok_or(errno!(EINVAL))?;
 	let _mountpoint = mount_points.get(&id).ok_or(errno!(EINVAL))?;
 
 	// TODO Check if busy (EBUSY)
@@ -449,34 +447,10 @@ pub fn remove(path: &Path) -> EResult<()> {
 
 	// TODO sync fs
 
-	path_to_id.remove(path);
+	loc_to_id.remove(target_location);
 	mount_points.remove(&id);
 
 	Ok(())
-}
-
-// TODO cleanup
-/// Returns the deepest mountpoint in the path `path`.
-///
-/// If no mountpoint is in the path, the function returns `None`.
-pub fn get_deepest(path: &Path) -> Option<Arc<Mutex<MountPoint>>> {
-	let container = MOUNT_POINTS.lock();
-	let mut max: Option<Arc<Mutex<MountPoint>>> = None;
-	for (_, mp) in container.iter() {
-		let mp_guard = mp.lock();
-		let mount_path = mp_guard.get_path();
-		if let Some(max) = max.as_mut() {
-			let max = max.lock();
-			let max_path = max.get_path();
-			if max_path.components().count() >= mount_path.components().count() {
-				continue;
-			}
-		}
-		if path.starts_with(mount_path) {
-			max = Some(mp.clone());
-		}
-	}
-	max
 }
 
 /// Returns the mountpoint with id `id`.
@@ -487,11 +461,11 @@ pub fn from_id(id: u32) -> Option<Arc<Mutex<MountPoint>>> {
 	container.get(&id).cloned()
 }
 
-/// Returns the mountpoint with path `path`.
+/// Returns the mountpoint that is mounted at the given `target_location`.
 ///
 /// If it doesn't exist, the function returns `None`.
-pub fn from_path(path: &Path) -> Option<Arc<Mutex<MountPoint>>> {
-	let container = PATH_TO_ID.lock();
-	let id = container.get(path)?;
+pub fn from_location(target_location: &FileLocation) -> Option<Arc<Mutex<MountPoint>>> {
+	let container = LOC_TO_ID.lock();
+	let id = container.get(target_location)?;
 	from_id(*id)
 }

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -50,8 +50,8 @@ pub const FLAG_SYNCHRONOUS: u32 = 0b100000000000;
 // TODO When removing a mountpoint, return an error if another mountpoint is
 // present in a subdir
 
-/// Enumeration of mount sources.
-#[derive(Eq, Hash, PartialEq)]
+/// Value specifying the device from which a filesystem is mounted.
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub enum MountSource {
 	/// The mountpoint is mounted from a device.
 	Device {
@@ -241,6 +241,7 @@ pub fn get_fs(source: &MountSource) -> Option<Arc<Mutex<dyn Filesystem>>> {
 }
 
 /// A mount point, allowing to attach a filesystem to a directory on the VFS.
+#[derive(Debug)]
 pub struct MountPoint {
 	/// The ID of the mountpoint.
 	id: u32,
@@ -379,13 +380,15 @@ pub static LOC_TO_ID: Mutex<HashMap<FileLocation, u32>> = Mutex::new(HashMap::ne
 /// - `target_path` is the path on which the filesystem is to be mounted.
 /// - `target_location` is the location on which the filesystem is to be mounted on the parent
 ///   filesystem.
+///
+/// The function returns the ID of the newly created mountpoint.
 pub fn create(
 	source: MountSource,
 	fs_type: Option<Arc<dyn FilesystemType>>,
 	flags: u32,
 	target_path: PathBuf,
 	target_location: FileLocation,
-) -> EResult<Arc<Mutex<MountPoint>>> {
+) -> EResult<u32> {
 	// TODO clean
 	// PATH_TO_ID is locked first and during the whole function to prevent a race condition between
 	// the locks of MOUNT_POINTS
@@ -401,10 +404,9 @@ pub fn create(
 		MOUNT_POINTS
 			.lock()
 			.iter()
-			.map(|(i, _)| *i)
+			.map(|(i, _)| *i + 1)
 			.max()
 			.unwrap_or(0)
-			+ 1
 	};
 
 	let mountpoint = Arc::new(Mutex::new(MountPoint::new(
@@ -426,7 +428,7 @@ pub fn create(
 		}
 	}
 
-	Ok(mountpoint)
+	Ok(id)
 }
 
 /// Removes the mountpoint at the given `target_location`.

--- a/src/file/mountpoint.rs
+++ b/src/file/mountpoint.rs
@@ -74,9 +74,9 @@ impl MountSource {
 	///
 	/// The string `string` might be either a kernfs name, a relative path or an
 	/// absolute path.
-	pub fn from_str(string: &[u8]) -> EResult<Self> {
+	pub fn new(string: &[u8]) -> EResult<Self> {
 		let path = Path::new(string)?;
-		let result = vfs::get_file_from_path(&path, &ResolutionSettings::kernel_follow());
+		let result = vfs::get_file_from_path(path, &ResolutionSettings::kernel_follow());
 		match result {
 			Ok(file_mutex) => {
 				let file = file_mutex.lock();

--- a/src/file/path.rs
+++ b/src/file/path.rs
@@ -25,7 +25,7 @@ impl PathBuf {
 	}
 
 	/// Creates a `PathBuf` without checking the length of the given [`String`].
-	pub fn from_unchecked(s: String) -> Self {
+	pub fn new_unchecked(s: String) -> Self {
 		Self(s)
 	}
 }
@@ -110,24 +110,16 @@ impl Deref for PathBuf {
 
 impl<'p> FromIterator<Component<'p>> for CollectResult<PathBuf> {
 	fn from_iter<T: IntoIterator<Item = Component<'p>>>(iter: T) -> Self {
-		Self(
-			iter.into_iter()
-				.map(|c| {
-					match c {
-						// The `/` is already inserted by `intersperse`
-						Component::RootDir => &[],
-						c => {
-							let s: &[u8] = c.as_ref();
-							s
-						}
-					}
-				})
-				.intersperse(b"/")
-				.flat_map(|s| s.into_iter().cloned())
-				.collect::<CollectResult<String>>()
-				.0
-				.map(PathBuf::from_unchecked),
-		)
+		let iter = iter.into_iter();
+		// TODO use `collect`
+		let res = (|| {
+			let mut path = String::new();
+			for c in iter {
+				path.push_str(c)?;
+			}
+			Ok(PathBuf::new_unchecked(path))
+		})();
+		Self(res)
 	}
 }
 
@@ -244,7 +236,7 @@ impl Path {
 	pub fn parent(&self) -> Option<&Path> {
 		let mut comps = self.components();
 		let last = comps.next_back();
-		last.and_then(|p| match p {
+		last.and_then(move |p| match p {
 			Component::RootDir => None,
 			_ => Some(comps.as_path()),
 		})
@@ -287,7 +279,7 @@ impl fmt::Debug for Path {
 }
 
 /// A component of a path.
-#[derive(Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum Component<'p> {
 	/// The root directory (heading `/`).
 	RootDir,
@@ -360,22 +352,16 @@ impl<'p> Components<'p> {
 	}
 
 	/// Returns a slice to the inner representation of the remaining data in the iterator.
-	pub fn as_slice(&self) -> &[u8] {
+	pub fn as_slice(&self) -> &'p [u8] {
 		&self.path.as_bytes()[self.front..self.back]
 	}
 
 	/// Returns a path representing the remaining data in the iterator.
-	pub fn as_path(&self) -> &Path {
+	pub fn as_path(&self) -> &'p Path {
 		Path::new_unchecked(self.as_slice())
 	}
 
 	fn next_impl(&mut self, backwards: bool) -> Option<Component<'p>> {
-		// Select the cursor according to the direction
-		let cursor = if !backwards {
-			&mut self.front
-		} else {
-			&mut self.back
-		};
 		// Get length of the next component
 		let comp_len = loop {
 			// Assert the fuse invariant
@@ -383,6 +369,7 @@ impl<'p> Components<'p> {
 				return None;
 			}
 			let slice = self.as_slice();
+			// Get offset to the next separator
 			let comp_len = if !backwards {
 				slice.iter().position(|c| *c == PATH_SEPARATOR)
 			} else {
@@ -392,15 +379,26 @@ impl<'p> Components<'p> {
 			if comp_len > 0 {
 				break comp_len;
 			}
-			*cursor += 1;
+			// The current character is a separator
+			let new_val = if !backwards {
+				self.front += 1;
+				self.front
+			} else {
+				self.back -= 1;
+				self.back
+			};
 			// If beginning with a separator, return root
-			if *cursor == 1 {
+			if new_val == 1 {
 				return Some(Component::RootDir);
 			}
 		};
 		// Return component
 		let comp_slice = &self.as_slice()[..comp_len];
-		*cursor += comp_len;
+		if !backwards {
+			self.front += comp_len;
+		} else {
+			self.back -= comp_len;
+		}
 		Some(Component::from(comp_slice))
 	}
 }
@@ -457,14 +455,14 @@ mod test {
 		let mut iter = path.components();
 		assert_eq!(iter.next(), Some(Component::RootDir));
 		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
-		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next(), None);
 
 		// Relative
 		let path = Path::new(b"etc/passwd").unwrap();
 		let mut iter = path.components();
 		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
-		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next(), None);
 
 		// Relative with `.` and `..`
@@ -474,7 +472,7 @@ mod test {
 		assert_eq!(iter.next(), Some(Component::CurDir));
 		assert_eq!(iter.next(), Some(Component::ParentDir));
 		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
-		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next(), None);
 	}
 
@@ -483,7 +481,7 @@ mod test {
 		// Absolute
 		let path = Path::new(b"/etc/passwd").unwrap();
 		let mut iter = path.components();
-		assert_eq!(iter.next_back(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
 		assert_eq!(iter.next_back(), Some(Component::RootDir));
 		assert_eq!(iter.next_back(), None);
@@ -491,14 +489,14 @@ mod test {
 		// Relative
 		let path = Path::new(b"etc/passwd").unwrap();
 		let mut iter = path.components();
-		assert_eq!(iter.next_back(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
 		assert_eq!(iter.next_back(), None);
 
 		// Relative with `.` and `..`
 		let path = Path::new(b"etc/./../etc/passwd").unwrap();
 		let mut iter = path.components();
-		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"passwd")));
 		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
 		assert_eq!(iter.next(), Some(Component::ParentDir));
 		assert_eq!(iter.next(), Some(Component::CurDir));

--- a/src/file/path.rs
+++ b/src/file/path.rs
@@ -152,6 +152,11 @@ impl Path {
 		unsafe { &*(s.as_ref() as *const [u8] as *const Self) }
 	}
 
+	/// Returns the length of the path in bytes.
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+
 	/// Tells whether the path is empty.
 	pub fn is_empty(&self) -> bool {
 		self.0.is_empty()

--- a/src/file/path.rs
+++ b/src/file/path.rs
@@ -380,25 +380,27 @@ impl<'p> Components<'p> {
 				break comp_len;
 			}
 			// The current character is a separator
-			let new_val = if !backwards {
+			let root = if !backwards {
 				self.front += 1;
-				self.front
+				self.front == 1
 			} else {
 				self.back -= 1;
-				self.back
+				self.back == 0
 			};
 			// If beginning with a separator, return root
-			if new_val == 1 {
+			if root {
 				return Some(Component::RootDir);
 			}
 		};
+		let slice = self.as_slice();
 		// Return component
-		let comp_slice = &self.as_slice()[..comp_len];
-		if !backwards {
+		let comp_slice = if !backwards {
 			self.front += comp_len;
+			&slice[..comp_len]
 		} else {
 			self.back -= comp_len;
-		}
+			&slice[(slice.len() - comp_len)..]
+		};
 		Some(Component::from(comp_slice))
 	}
 }
@@ -496,11 +498,11 @@ mod test {
 		// Relative with `.` and `..`
 		let path = Path::new(b"etc/./../etc/passwd").unwrap();
 		let mut iter = path.components();
-		assert_eq!(iter.next(), Some(Component::Normal(b"passwd")));
-		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
-		assert_eq!(iter.next(), Some(Component::ParentDir));
-		assert_eq!(iter.next(), Some(Component::CurDir));
-		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
-		assert_eq!(iter.next(), None);
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"passwd")));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next_back(), Some(Component::ParentDir));
+		assert_eq!(iter.next_back(), Some(Component::CurDir));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next_back(), None);
 	}
 }

--- a/src/file/path.rs
+++ b/src/file/path.rs
@@ -1,236 +1,350 @@
-//! This module handles files path.
+//! This module implements structure to represent file paths.
 
-use crate::errno;
-use crate::errno::AllocResult;
-use crate::errno::Errno;
-use crate::limits;
+use crate::errno::{AllocError, AllocResult, CollectResult, EResult, Errno};
 use crate::util::container::string::String;
-use crate::util::container::vec::Vec;
-use crate::util::TryClone;
-use core::cmp::min;
+use crate::util::{DisplayableStr, TryClone};
+use crate::{errno, limits};
+use core::borrow::Borrow;
 use core::fmt;
+use core::fmt::Formatter;
 use core::hash::Hash;
-use core::ops::Add;
-use core::ops::Index;
-use core::ops::IndexMut;
-use core::ops::Range;
-use core::ops::RangeFrom;
-use core::ops::RangeTo;
+use core::iter::FusedIterator;
+use core::ops::Deref;
 
 /// The character used as a path separator.
-pub const PATH_SEPARATOR: char = '/';
+pub const PATH_SEPARATOR: u8 = b'/';
 
-/// A structure representing a path to a file.
-#[derive(Debug, Eq, Hash, PartialEq)]
-pub struct Path {
-	/// Tells whether the path is absolute or relative.
-	absolute: bool,
-	/// An array containing the different parts of the path which are separated
-	/// with `/`.
-	parts: Vec<String>,
+/// Owned file path.
+#[derive(Default, Eq, Hash, PartialEq)]
+pub struct PathBuf(String);
+
+impl PathBuf {
+	/// Creates a new path to root.
+	pub fn root() -> Self {
+		Self(String::default())
+	}
 }
+
+impl TryFrom<String> for PathBuf {
+	type Error = Errno;
+
+	/// Creates a new instance from the given string.
+	///
+	/// If the total length of the path is longer than [`limits::PATH_MAX`], the function returns
+	/// an error ([`errno::ENAMETOOLONG`]).
+	fn try_from(s: String) -> EResult<Self> {
+		if s.len() > limits::PATH_MAX {
+			return Err(errno!(ENAMETOOLONG));
+		}
+		Ok(Self(s))
+	}
+}
+
+impl TryClone for PathBuf {
+	type Error = AllocError;
+
+	fn try_clone(&self) -> AllocResult<Self> {
+		Ok(Self(self.0.try_clone()?))
+	}
+}
+
+impl TryFrom<&Path> for PathBuf {
+	type Error = AllocError;
+
+	fn try_from(s: &Path) -> AllocResult<Self> {
+		Ok(Self(String::try_from(&s.0)?))
+	}
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for PathBuf {
+	type Error = Errno;
+
+	/// Creates a new instance from the given string.
+	///
+	/// If the total length of the path is longer than [`limits::PATH_MAX`], the function returns
+	/// an error ([`errno::ENAMETOOLONG`]).
+	fn try_from(s: &[u8; N]) -> EResult<Self> {
+		Self::try_from(s.as_slice())
+	}
+}
+
+impl TryFrom<&[u8]> for PathBuf {
+	type Error = Errno;
+
+	/// Creates a new instance from the given string.
+	///
+	/// If the total length of the path is longer than [`limits::PATH_MAX`], the function returns
+	/// an error ([`errno::ENAMETOOLONG`]).
+	fn try_from(s: &[u8]) -> EResult<Self> {
+		if s.len() > limits::PATH_MAX {
+			return Err(errno!(ENAMETOOLONG));
+		}
+		Ok(Self(String::try_from(s)?))
+	}
+}
+
+impl AsRef<Path> for PathBuf {
+	fn as_ref(&self) -> &Path {
+		Path::new_unchecked(self.0.as_bytes())
+	}
+}
+
+impl Borrow<Path> for PathBuf {
+	fn borrow(&self) -> &Path {
+		self.as_ref()
+	}
+}
+
+impl Deref for PathBuf {
+	type Target = Path;
+
+	fn deref(&self) -> &Self::Target {
+		self.as_ref()
+	}
+}
+
+impl<'p> FromIterator<Component<'p>> for CollectResult<PathBuf> {
+	fn from_iter<T: IntoIterator<Item = Component<'p>>>(iter: T) -> Self {
+		// TODO
+		todo!()
+	}
+}
+
+impl fmt::Display for PathBuf {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		fmt::Display::fmt(self.as_ref(), f)
+	}
+}
+
+impl fmt::Debug for PathBuf {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(self.as_ref(), f)
+	}
+}
+
+/// Borrowed file path.
+#[derive(Eq, Hash, PartialEq)]
+// repr(transparent) is required for the `new` function to work correctly
+#[repr(transparent)]
+pub struct Path([u8]);
 
 impl Path {
-	/// Creates a new instance to the root directory.
-	pub const fn root() -> Self {
-		Self {
-			absolute: true,
-			parts: Vec::new(),
-		}
+	/// Creates a new path to root.
+	pub fn root() -> &'static Self {
+		Self::new_unchecked(&[])
 	}
 
-	/// Creates a new instance from string.
+	/// Creates a new instance from the given string.
 	///
-	/// Arguments:
-	/// - `path` is the path.
-	/// - `user` tells whether the path was supplied by the user (to check the
-	/// length and return an error if too long).
-	pub fn from_str(path: &[u8], user: bool) -> Result<Self, Errno> {
-		if user && path.len() + 1 >= limits::PATH_MAX {
-			return Err(errno!(ENAMETOOLONG));
-		}
-
-		let mut parts = Vec::new();
-		for p in path.split(|c| *c == PATH_SEPARATOR as u8) {
-			if p.len() > limits::NAME_MAX {
-				return Err(errno!(ENAMETOOLONG));
-			}
-
-			if !p.is_empty() {
-				parts.push(p.try_into()?)?;
-			}
-		}
-
-		Ok(Self {
-			absolute: path.first() == Some(&(PATH_SEPARATOR as u8)),
-			parts,
-		})
-	}
-
-	/// Tells whether the path is absolute or not.
-	pub fn is_absolute(&self) -> bool {
-		self.absolute
-	}
-
-	/// Sets whether the path is absolute.
-	pub fn set_absolute(&mut self, absolute: bool) {
-		self.absolute = absolute;
-	}
-
-	/// Tells whether the path is empty.
-	pub fn is_empty(&self) -> bool {
-		self.parts.is_empty()
-	}
-
-	/// Returns the number of elements in the path, namely, the number of
-	/// elements separated by `/`.
-	pub fn get_elements_count(&self) -> usize {
-		self.parts.len()
-	}
-
-	/// Pushes the given filename `filename` onto the path.
-	pub fn push(&mut self, filename: String) -> Result<(), Errno> {
-		if filename.len() + 1 >= limits::NAME_MAX {
-			return Err(errno!(ENAMETOOLONG));
-		}
-
-		self.parts.push(filename)?;
-		Ok(())
-	}
-
-	/// Pops the filename on top of the path.
-	pub fn pop(&mut self) -> Option<String> {
-		self.parts.pop()
-	}
-
-	/// Returns a reference to the last element.
-	///
-	/// If the path is empty, the function returns `None`.
-	pub fn last(&self) -> Option<&String> {
-		self.parts.as_slice().last()
-	}
-
-	/// Tells whether the current path begins with the path `other`.
-	pub fn begins_with(&self, other: &Self) -> bool {
-		if self.absolute != other.absolute {
-			return false;
-		}
-		if self.parts.len() < other.parts.len() {
-			return false;
-		}
-
-		let len = min(self.parts.len(), other.parts.len());
-		for i in 0..len {
-			if self.parts[i] != other.parts[i] {
-				return false;
-			}
-		}
-
-		true
-	}
-
-	/// Returns a subpath in the given range `range`.
-	pub fn range(&self, range: Range<usize>) -> Result<Path, Errno> {
-		Ok(Self {
-			absolute: self.absolute,
-			parts: self.parts.clone_range(range)?,
-		})
-	}
-
-	/// Returns a subpath in the given range `range`.
-	pub fn range_from(&self, range: RangeFrom<usize>) -> Result<Path, Errno> {
-		Ok(Self {
-			absolute: self.absolute,
-			parts: self.parts.clone_range_from(range)?,
-		})
-	}
-
-	/// Returns a subpath in the given range `range`.
-	pub fn range_to(&self, range: RangeTo<usize>) -> Result<Path, Errno> {
-		Ok(Self {
-			absolute: self.absolute,
-			parts: self.parts.clone_range_to(range)?,
-		})
-	}
-
-	/// Concats the current path with another path `other` to create a new path.
-	///
-	/// If the `other` path is absolute, the resulting path exactly equals
-	/// `other`.
-	pub fn concat(&self, other: &Self) -> AllocResult<Self> {
-		if other.is_absolute() {
-			other.try_clone()
+	/// If the total length of the path is longer than [`limits::PATH_MAX`], the function returns
+	/// an error ([`errno::ENAMETOOLONG`]).
+	pub fn new<S: AsRef<[u8]> + ?Sized>(s: &S) -> EResult<&Self> {
+		let slice = s.as_ref();
+		if slice.len() <= limits::PATH_MAX {
+			Ok(Self::new_unchecked(slice))
 		} else {
-			let mut self_parts = self.parts.try_clone()?;
-			let mut other_parts = other.parts.try_clone()?;
-			self_parts.append(&mut other_parts)?;
-
-			Ok(Self {
-				absolute: self.absolute,
-				parts: self_parts,
-			})
+			Err(errno!(ENAMETOOLONG))
 		}
 	}
-}
 
-impl Default for Path {
-	fn default() -> Self {
-		Self::root()
+	/// Creates a new instance from the given string without checking its length.
+	pub fn new_unchecked<S: AsRef<[u8]> + ?Sized>(s: &S) -> &Self {
+		unsafe { &*(s.as_ref() as *const [u8] as *const Self) }
+	}
+
+	/// Tells whether the path is absolute.
+	pub fn is_absolute(&self) -> bool {
+		matches!(self.0.first(), None | Some(&PATH_SEPARATOR))
+	}
+
+	/// Returns slice of the bytes representation of the path.
+	pub fn as_bytes(&self) -> &[u8] {
+		&self.0
+	}
+
+	/// Clones the path and returns a [`PathBuf`].
+	pub fn to_path_buf(&self) -> AllocResult<PathBuf> {
+		PathBuf::try_from(self)
+	}
+
+	/// Joins the path with another.
+	///
+	/// If `path` is absolute, it replaces the current path.
+	///
+	/// The function does not check path length and allows longer paths than [`limits::PATH_MAX`].
+	pub fn join<P: AsRef<Path>>(&self, path: P) -> AllocResult<PathBuf> {
+		let path = path.as_ref();
+		if path.is_absolute() {
+			path.as_ref().to_path_buf()
+		} else {
+			self.components()
+				.chain(path.components())
+				.collect::<CollectResult<PathBuf>>()
+				.0
+		}
+	}
+
+	/// Returns an iterator over the path's components.
+	pub fn components(&self) -> Components {
+		Components {
+			path: self,
+
+			front: 0,
+			back: self.0.len(),
+		}
+	}
+
+	/// Returns the final component of the path.
+	///
+	/// This function returns `None` only if it terminates with root.
+	pub fn file_name(&self) -> Option<&[u8]> {
+		let comp = self.components().next_back()?;
+		match comp {
+			Component::RootDir => None,
+			Component::CurDir => Some(b"."),
+			Component::ParentDir => Some(b".."),
+			Component::Normal(name) => Some(name),
+		}
+	}
+
+	/// Returns the path without its final component.
+	///
+	/// This function returns `None` only if it terminates with root.
+	pub fn parent(&self) -> Option<&Path> {
+		// TODO
+		todo!()
+	}
+
+	/// Tells whether the path starts with the given `base`.
+	pub fn starts_with<P: AsRef<Path>>(&self, base: P) -> bool {
+		let base = base.as_ref();
+		self.components()
+			.zip(base.components())
+			.all(|(path, base)| path == base)
+	}
+
+	/// Strips the path from the given `prefix` and returns the remaining components.
+	///
+	/// If the path does not start with the given `prefix`, the function returns `None`.
+	pub fn strip_prefix<P: AsRef<Path>>(&self, prefix: P) -> Option<&Path> {
+		let prefix = prefix.as_ref();
+		let slice = self.0.strip_prefix(&prefix.0)?;
+		Some(Self::new_unchecked(slice))
 	}
 }
 
-impl Add for Path {
-	type Output = AllocResult<Self>;
-
-	fn add(self, other: Self) -> Self::Output {
-		self.concat(&other)
+impl AsRef<Path> for Path {
+	fn as_ref(&self) -> &Path {
+		self
 	}
 }
-
-impl TryClone for Path {
-	fn try_clone(&self) -> AllocResult<Self> {
-		Ok(Self {
-			absolute: self.absolute,
-			parts: self.parts.try_clone()?,
-		})
-	}
-}
-
-impl Index<usize> for Path {
-	type Output = String;
-
-	#[inline]
-	fn index(&self, index: usize) -> &Self::Output {
-		&self.parts[index]
-	}
-}
-
-impl IndexMut<usize> for Path {
-	#[inline]
-	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-		&mut self.parts[index]
-	}
-}
-
-// TODO Iterator
 
 impl fmt::Display for Path {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		if self.is_absolute() {
-			write!(f, "/")?;
-		}
-
-		for i in 0..self.get_elements_count() {
-			write!(f, "{}", self[i])?;
-
-			if i + 1 < self.get_elements_count() {
-				write!(f, "/")?;
-			}
-		}
-
-		Ok(())
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		fmt::Display::fmt(&DisplayableStr(&self.0), f)
 	}
 }
+
+impl fmt::Debug for Path {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(&DisplayableStr(&self.0), f)
+	}
+}
+
+/// A component of a path.
+#[derive(Eq, PartialEq)]
+pub enum Component<'p> {
+	/// The root directory (heading `/`).
+	RootDir,
+	/// The current directory (`.`).
+	CurDir,
+	/// The parent directory (`..`).
+	ParentDir,
+	/// A normal component.
+	Normal(&'p [u8]),
+}
+
+impl<'p> AsRef<[u8]> for Component<'p> {
+	fn as_ref(&self) -> &[u8] {
+		match self {
+			Component::RootDir => b"/",
+			Component::CurDir => b".",
+			Component::ParentDir => b"..",
+			Component::Normal(name) => name,
+		}
+	}
+}
+
+impl<'p> AsRef<Path> for Component<'p> {
+	fn as_ref(&self) -> &Path {
+		let slice: &[u8] = self.as_ref();
+		Path::new_unchecked(slice)
+	}
+}
+
+impl<'p> fmt::Debug for Component<'p> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		match self {
+			Component::RootDir => write!(f, "RootDir"),
+			Component::CurDir => write!(f, "CurDir"),
+			Component::ParentDir => write!(f, "ParentDir"),
+			Component::Normal(name) => write!(f, "Normal({})", DisplayableStr(name)),
+		}
+	}
+}
+
+/// Iterator over a path's components.
+pub struct Components<'p> {
+	/// The path over which the iterator works.
+	path: &'p Path,
+
+	/// The current front offset.
+	front: usize,
+	/// The current back offset.
+	back: usize,
+}
+
+impl<'p> Components<'p> {
+	/// Tells whether the iterator is finished.
+	fn is_finished(&self) -> bool {
+		self.front >= self.back
+	}
+}
+
+impl<'p> Iterator for Components<'p> {
+	type Item = Component<'p>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		// Assert the fuse invariant
+		if self.is_finished() {
+			return None;
+		}
+		let slice = &self.path.0[self.front..self.back];
+
+		if self.front == 0 && slice.first().cloned() == Some(PATH_SEPARATOR) {
+			self.front += 1;
+			return Some(Component::RootDir);
+		}
+
+		// TODO
+		todo!()
+	}
+}
+
+impl<'p> DoubleEndedIterator for Components<'p> {
+	fn next_back(&mut self) -> Option<Self::Item> {
+		// Assert the fuse invariant
+		if self.is_finished() {
+			return None;
+		}
+		let slice = &self.path.0[self.front..self.back];
+
+		// TODO
+		todo!()
+	}
+}
+
+impl<'p> FusedIterator for Components<'p> {}
 
 #[cfg(test)]
 mod test {
@@ -238,28 +352,82 @@ mod test {
 
 	#[test_case]
 	fn path_absolute0() {
-		assert!(Path::from_str(b"/", false).unwrap().is_absolute());
+		assert!(Path::new(b"/").unwrap().is_absolute());
 	}
 
 	#[test_case]
 	fn path_absolute1() {
-		assert!(Path::from_str(b"/.", false).unwrap().is_absolute());
+		assert!(Path::new(b"/.").unwrap().is_absolute());
 	}
 
 	#[test_case]
 	fn path_absolute2() {
-		assert!(!Path::from_str(b".", false).unwrap().is_absolute());
+		assert!(!Path::new(b".").unwrap().is_absolute());
 	}
 
 	#[test_case]
 	fn path_absolute3() {
-		assert!(!Path::from_str(b"..", false).unwrap().is_absolute());
+		assert!(!Path::new(b"..").unwrap().is_absolute());
 	}
 
 	#[test_case]
 	fn path_absolute4() {
-		assert!(!Path::from_str(b"./", false).unwrap().is_absolute());
+		assert!(!Path::new(b"./").unwrap().is_absolute());
 	}
 
-	// TODO test concat
+	#[test_case]
+	fn components() {
+		// Absolute
+		let path = Path::new(b"/etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next(), Some(Component::RootDir));
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), None);
+
+		// Relative
+		let path = Path::new(b"etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), None);
+
+		// Relative with `.` and `..`
+		let path = Path::new(b"etc/./../etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), Some(Component::CurDir));
+		assert_eq!(iter.next(), Some(Component::ParentDir));
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), None);
+	}
+
+	#[test_case]
+	fn components_back() {
+		// Absolute
+		let path = Path::new(b"/etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next_back(), Some(Component::RootDir));
+		assert_eq!(iter.next_back(), None);
+
+		// Relative
+		let path = Path::new(b"etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next_back(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next_back(), None);
+
+		// Relative with `.` and `..`
+		let path = Path::new(b"etc/./../etc/passwd").unwrap();
+		let mut iter = path.components();
+		assert_eq!(iter.next(), Some(Component::Normal(b"password")));
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), Some(Component::ParentDir));
+		assert_eq!(iter.next(), Some(Component::CurDir));
+		assert_eq!(iter.next(), Some(Component::Normal(b"etc")));
+		assert_eq!(iter.next(), None);
+	}
 }

--- a/src/file/path.rs
+++ b/src/file/path.rs
@@ -152,9 +152,14 @@ impl Path {
 		unsafe { &*(s.as_ref() as *const [u8] as *const Self) }
 	}
 
+	/// Tells whether the path is empty.
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+
 	/// Tells whether the path is absolute.
 	pub fn is_absolute(&self) -> bool {
-		matches!(self.0.first(), None | Some(&PATH_SEPARATOR))
+		self.0.first().cloned() == Some(PATH_SEPARATOR)
 	}
 
 	/// Returns slice of the bytes representation of the path.

--- a/src/file/util.rs
+++ b/src/file/util.rs
@@ -11,6 +11,7 @@ use crate::util::container::string::String;
 use crate::util::io::IO;
 use crate::util::TryClone;
 use crate::{errno, memory};
+use crate::file::vfs::{ResolutionSettings};
 
 /// Creates the directories necessary to reach path `path`.
 ///
@@ -22,7 +23,7 @@ pub fn create_dirs(path: &Path) -> EResult<()> {
 		let Component::Normal(name) = &comp else {
 			continue;
 		};
-		if let Ok(parent_mutex) = vfs::get_file_from_path(&p, &AccessProfile::KERNEL, true) {
+		if let Ok(parent_mutex) = vfs::get_file_from_path(&p, &ResolutionSettings::kernel_follow()) {
 			let mut parent = parent_mutex.lock();
 			let res = vfs::create_file(
 				&mut parent,
@@ -42,15 +43,16 @@ pub fn create_dirs(path: &Path) -> EResult<()> {
 }
 
 /// Copies the file `old` into the directory `new_parent` with name `new_name`.
-pub fn copy_file(old: &mut File, new_parent: &mut File, new_name: String) -> EResult<()> {
-	let ap = AccessProfile::from_file(old);
+///
+/// `rs` is the settings for path resolution.
+pub fn copy_file(old: &mut File, new_parent: &mut File, new_name: String, rs: &ResolutionSettings) -> EResult<()> {
 	let mode = old.get_mode();
 
 	match old.get_content() {
 		// Copy the file and its content
 		FileContent::Regular => {
 			let new_mutex =
-				vfs::create_file(new_parent, new_name, &ap, mode, FileContent::Regular)?;
+				vfs::create_file(new_parent, new_name, &rs.access_profile, mode, FileContent::Regular)?;
 			let mut new = new_mutex.lock();
 
 			// TODO On fail, remove file
@@ -73,48 +75,56 @@ pub fn copy_file(old: &mut File, new_parent: &mut File, new_name: String) -> ERe
 			let new_mutex = vfs::create_file(
 				new_parent,
 				new_name,
-				&ap,
+				&rs.access_profile,
 				mode,
 				FileContent::Directory(HashMap::new()),
 			)?;
 			let mut new = new_mutex.lock();
+			let rs = ResolutionSettings {
+				start: new.get_location().clone(),
+				..rs.clone()
+			};
 
 			// TODO On fail, undo
 			for (name, _) in entries.iter() {
-				let old_mutex = vfs::get_file_from_parent(&new, name.try_clone()?, &ap, false)?;
+				let old_mutex = vfs::get_file_from_path(Path::new(name)?, &rs)?;
 				let mut old = old_mutex.lock();
 
-				copy_file(&mut old, &mut new, name.try_clone()?)?;
+				copy_file(&mut old, &mut new, name.try_clone()?, &rs)?;
 			}
 		}
 
 		// Copy the file
 		content => {
-			vfs::create_file(new_parent, new_name, &ap, mode, content.try_clone()?)?;
+			vfs::create_file(new_parent, new_name, &rs.access_profile, mode, content.try_clone()?)?;
 		}
 	}
 
 	Ok(())
 }
 
-/// Removes the file `file` and its subfiles recursively if it's a directory.
+/// Removes the given `file` and if it's a directory, its subfiles recursively.
 ///
 /// Arguments:
 /// - `file` is the root file to remove
-/// - `access_profile` is the access profile, to check permissions
-pub fn remove_recursive(file: &mut File, access_profile: &AccessProfile) -> EResult<()> {
+/// - `rs` is the settings for path resolution.
+pub fn remove_recursive(file: &mut File, rs: &ResolutionSettings) -> EResult<()> {
 	match file.get_content() {
 		FileContent::Directory(entries) => {
+			let rs = ResolutionSettings {
+				start: file.get_location().clone(),
+				..rs.clone()
+			};
 			for (name, _) in entries.iter() {
-				let name = name.try_clone()?;
-				let subfile_mutex = vfs::get_file_from_parent(file, name, access_profile, false)?;
+				let name = Path::new(name)?;
+				let subfile_mutex = vfs::get_file_from_path(name, &rs)?;
 				let mut subfile = subfile_mutex.lock();
 
-				remove_recursive(&mut subfile, access_profile)?;
+				remove_recursive(&mut subfile, &rs)?;
 			}
 		}
 
-		_ => vfs::remove_file(file, access_profile)?,
+		_ => vfs::remove_file(file, &rs.access_profile)?,
 	}
 
 	Ok(())

--- a/src/file/util.rs
+++ b/src/file/util.rs
@@ -1,17 +1,14 @@
 //! This module implements utility functions for files manipulations.
 
 use super::path::{Component, Path, PathBuf};
-use super::File;
 use super::FileContent;
+use crate::errno;
 use crate::errno::EResult;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::util::container::hashmap::HashMap;
 use crate::util::container::string::String;
-use crate::util::io::IO;
-use crate::util::TryClone;
-use crate::{errno, memory};
 
 /// Creates the directories necessary to reach path `path`.
 ///
@@ -38,111 +35,7 @@ pub fn create_dirs(path: &Path) -> EResult<()> {
 				_ => {}
 			}
 		}
-		p.join(comp)?;
+		p = p.join(comp)?;
 	}
-	Ok(())
-}
-
-/// Copies the file `old` into the directory `new_parent` with name `new_name`.
-///
-/// `rs` is the settings for path resolution.
-pub fn copy_file(
-	old: &mut File,
-	new_parent: &mut File,
-	new_name: String,
-	rs: &ResolutionSettings,
-) -> EResult<()> {
-	let mode = old.get_mode();
-
-	match old.get_content() {
-		// Copy the file and its content
-		FileContent::Regular => {
-			let new_mutex = vfs::create_file(
-				new_parent,
-				new_name,
-				&rs.access_profile,
-				mode,
-				FileContent::Regular,
-			)?;
-			let mut new = new_mutex.lock();
-
-			// TODO On fail, remove file
-			// Copying content
-			let mut off = 0;
-			let mut buff: [u8; memory::PAGE_SIZE] = [0; memory::PAGE_SIZE];
-			loop {
-				let (len, eof) = old.read(off, &mut buff)?;
-				if eof {
-					break;
-				}
-
-				new.write(off, &buff)?;
-				off += len;
-			}
-		}
-
-		// Copy the directory recursively
-		FileContent::Directory(entries) => {
-			let new_mutex = vfs::create_file(
-				new_parent,
-				new_name,
-				&rs.access_profile,
-				mode,
-				FileContent::Directory(HashMap::new()),
-			)?;
-			let mut new = new_mutex.lock();
-			let rs = ResolutionSettings {
-				start: new.get_location().clone(),
-				..rs.clone()
-			};
-
-			// TODO On fail, undo
-			for (name, _) in entries.iter() {
-				let old_mutex = vfs::get_file_from_path(Path::new(name)?, &rs)?;
-				let mut old = old_mutex.lock();
-
-				copy_file(&mut old, &mut new, name.try_clone()?, &rs)?;
-			}
-		}
-
-		// Copy the file
-		content => {
-			vfs::create_file(
-				new_parent,
-				new_name,
-				&rs.access_profile,
-				mode,
-				content.try_clone()?,
-			)?;
-		}
-	}
-
-	Ok(())
-}
-
-/// Removes the given `file` and if it's a directory, its subfiles recursively.
-///
-/// Arguments:
-/// - `file` is the root file to remove
-/// - `rs` is the settings for path resolution.
-pub fn remove_recursive(file: &mut File, rs: &ResolutionSettings) -> EResult<()> {
-	match file.get_content() {
-		FileContent::Directory(entries) => {
-			let rs = ResolutionSettings {
-				start: file.get_location().clone(),
-				..rs.clone()
-			};
-			for (name, _) in entries.iter() {
-				let name = Path::new(name)?;
-				let subfile_mutex = vfs::get_file_from_path(name, &rs)?;
-				let mut subfile = subfile_mutex.lock();
-
-				remove_recursive(&mut subfile, &rs)?;
-			}
-		}
-
-		_ => vfs::remove_file(file, &rs.access_profile)?,
-	}
-
 	Ok(())
 }

--- a/src/file/util.rs
+++ b/src/file/util.rs
@@ -1,56 +1,44 @@
 //! This module implements utility functions for files manipulations.
 
-use super::path::Path;
+use super::path::{Component, Path, PathBuf};
 use super::File;
 use super::FileContent;
-use crate::errno;
 use crate::errno::EResult;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
-use crate::memory;
 use crate::util::container::hashmap::HashMap;
 use crate::util::container::string::String;
 use crate::util::io::IO;
 use crate::util::TryClone;
+use crate::{errno, memory};
 
 /// Creates the directories necessary to reach path `path`.
 ///
-/// On success, the function returns the number of created directories (without the directories
-/// that already existed).
-///
 /// If relative, the path is taken from the root.
-pub fn create_dirs(path: &Path) -> EResult<usize> {
-	let path = Path::root().concat(path)?;
-
+pub fn create_dirs(path: &Path) -> EResult<()> {
 	// Path of the parent directory
-	let mut p = Path::root();
-	// Number of created directories
-	let mut created_count = 0;
-
-	for i in 0..path.get_elements_count() {
-		let name = path[i].try_clone()?;
-
+	let mut p = PathBuf::root();
+	for comp in path.components() {
+		let Component::Normal(name) = &comp else {
+			continue;
+		};
 		if let Ok(parent_mutex) = vfs::get_file_from_path(&p, &AccessProfile::KERNEL, true) {
 			let mut parent = parent_mutex.lock();
-
-			match vfs::create_file(
+			let res = vfs::create_file(
 				&mut parent,
-				name.try_clone()?,
+				String::try_from(*name)?,
 				&AccessProfile::KERNEL,
 				0o755,
 				FileContent::Directory(HashMap::new()),
-			) {
-				Ok(_) => created_count += 1,
+			);
+			match res {
 				Err(e) if e.as_int() != errno::EEXIST => return Err(e),
-
 				_ => {}
 			}
 		}
-
-		p.push(name)?;
+		p.join(comp)?;
 	}
-
-	Ok(created_count)
+	Ok(())
 }
 
 /// Copies the file `old` into the directory `new_parent` with name `new_name`.

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -28,198 +28,6 @@ use core::ptr::NonNull;
 
 // TODO implement and use cache
 
-/// Settings for a path resolution operation.
-#[derive(Clone)]
-pub struct ResolutionSettings<'s> {
-	/// The location of the root directory for the operation.
-	///
-	/// Contrary to the `start` field, resolution *cannot* access a parent of this path.
-	pub root: FileLocation,
-	/// The beginning position of the path resolution.
-	pub start: FileLocation,
-
-	/// The access profile to use for resolution.
-	pub access_profile: &'s AccessProfile,
-
-	/// If `true`, the path is resolved for creation, meaning the operation will not fail if the
-	/// file does not exist.
-	pub create: bool,
-	/// If `true`, path resolution follows symbolic links.
-	pub follow_links: bool,
-}
-
-impl<'s> ResolutionSettings<'s> {
-	/// Kernel access, following symbolic links.
-	pub const fn kernel_follow() -> Self {
-		Self {
-			root: FileLocation::root(),
-			start: FileLocation::root(),
-
-			access_profile: &AccessProfile::KERNEL,
-
-			create: false,
-			follow_links: true,
-		}
-	}
-
-	/// Kernel access, without following symbolic links.
-	pub const fn kernel_nofollow() -> Self {
-		Self {
-			follow_links: false,
-			..Self::kernel_follow()
-		}
-	}
-
-	/// Returns the default for the given process.
-	///
-	/// `follow_links` tells whether symbolic links are followed.
-	pub fn for_process(proc: &'s Process, follow_links: bool) -> Self {
-		Self {
-			root: proc.chroot.clone(),
-			start: proc.cwd.1.clone(),
-
-			access_profile: &proc.access_profile,
-
-			create: false,
-			follow_links,
-		}
-	}
-}
-
-/// The resolute of the path resolution operation.
-pub enum Resolved<'s> {
-	/// The file has been found.
-	Found(Arc<Mutex<File>>),
-	/// The file can be created.
-	///
-	/// This variant can be returned only if the `create` field is set to `true` in
-	/// [`ResolutionSettings`].
-	Creatable {
-		/// The parent directory in which the file is to be created.
-		parent: Arc<Mutex<File>>,
-		/// The name of the file to be created.
-		name: &'s [u8],
-	},
-}
-
-/// Like [`get_file_from_path`], but returns `None` is the file does not exist.
-pub fn get_file_from_path_opt(
-	path: &Path,
-	resolution_settings: &ResolutionSettings,
-) -> EResult<Option<Arc<Mutex<File>>>> {
-	let file = match resolve_path(path, resolution_settings)? {
-		Resolved::Found(file) => Some(file),
-		_ => None,
-	};
-	Ok(file)
-}
-
-/// Returns the file at the given `path`.
-///
-/// If the file does not exist, the function returns [`ENOENT`].
-pub fn get_file_from_path(
-	path: &Path,
-	resolution_settings: &ResolutionSettings,
-) -> EResult<Arc<Mutex<File>>> {
-	get_file_from_path_opt(path, resolution_settings)?.ok_or_else(|| errno!(ENOENT))
-}
-
-/// Resolves the given `path` with the given `settings`.
-///
-/// The following conditions can cause errors:
-/// - If the path is empty, the function returns [`errno::ENOMEM`].
-/// - If a component of the path cannot be accessed with the provided access profile, the function
-///   returns [`errno::EACCES`].
-/// - If a component of the path (excluding the last) is not a directory nor a symbolic link, the
-///   function returns [`errno::ENOTDIR`].
-/// - If a component of the path (excluding the last) is a symbolic link and following them is
-///   disabled, the function returns [`errno::ENOTDIR`].
-/// - If the resolution of the path requires more symbolic link indirections than
-///   [`limits::SYMLOOP_MAX`], the function returns [`errno::ELOOP`].
-pub fn resolve_path<'p>(path: &'p Path, settings: &ResolutionSettings) -> EResult<Resolved<'p>> {
-	// Required by POSIX
-	if path.is_empty() {
-		return Err(errno!(ENOENT));
-	}
-
-	// Get start file
-	let start = if path.is_absolute() {
-		&settings.root
-	} else {
-		&settings.start
-	};
-	let mut file_mutex = get_file_from_location(start)?;
-
-	// Iterate on components
-	let mut iter = path.components().peekable();
-	for comp in &mut iter {
-		let file = file_mutex.lock();
-		let name = match comp {
-			Component::ParentDir if file.get_location() != &settings.root => b"..",
-			Component::Normal(name) => name,
-			// Ignore
-			_ => continue,
-		};
-		match file.get_content() {
-			FileContent::Directory(entries) => {
-				// Check permission
-				if !settings.access_profile.can_search_directory(&file) {
-					return Err(errno!(EACCES));
-				}
-				let Some(entry) = entries.get(name) else {
-					// If this is the last component
-					let is_last = iter.peek().is_none();
-					// If the last component does not exist and the file may be created
-					let res = if is_last && settings.create {
-						Ok(Resolved::Creatable {
-							parent: file_mutex,
-							name,
-						})
-					} else {
-						Err(errno!(ENOENT))
-					};
-					return res;
-				};
-				let mountpoint_id = file
-					.location
-					.get_mountpoint_id()
-					.ok_or_else(|| errno!(ENOENT))?;
-				// The location on the current filesystem
-				let mut loc = FileLocation::Filesystem {
-					mountpoint_id,
-					inode: entry.inode,
-				};
-				// Update location if on a different mountpoint
-				if let Some(mountpoint) = mountpoint::from_location(&loc) {
-					loc = mountpoint.lock().get_target_location().clone();
-				}
-				file_mutex = get_file_from_location(&loc)?;
-			}
-			// Follow link, if enabled
-			FileContent::Link(link_path) if settings.follow_links => {
-				// TODO resolve link
-				todo!()
-			}
-			_ => return Err(errno!(ENOTDIR)),
-		}
-	}
-
-	Ok(Resolved::Found(file_mutex))
-}
-
-/// Updates the location of the file `file` according to the given mountpoint
-/// `mountpoint`.
-///
-/// If the file in not located on a filesystem, the function does nothing.
-fn update_location(file: &mut File, mountpoint: &MountPoint) {
-	if let FileLocation::Filesystem {
-		mountpoint_id, ..
-	} = &mut file.location
-	{
-		*mountpoint_id = mountpoint.get_id();
-	}
-}
-
 /// Returns the file corresponding to the given location `location`.
 ///
 /// This function doesn't set the name of the file since it cannot be known solely on its
@@ -266,6 +74,230 @@ pub fn get_file_from_location(location: &FileLocation) -> EResult<Arc<Mutex<File
 			Ok(file)
 		}
 	}
+}
+
+/// Settings for a path resolution operation.
+#[derive(Clone)]
+pub struct ResolutionSettings<'s> {
+	/// The location of the root directory for the operation.
+	///
+	/// Contrary to the `start` field, resolution *cannot* access a parent of this path.
+	pub root: FileLocation,
+	/// The beginning position of the path resolution.
+	pub start: FileLocation,
+
+	/// The access profile to use for resolution.
+	pub access_profile: &'s AccessProfile,
+
+	/// If `true`, the path is resolved for creation, meaning the operation will not fail if the
+	/// file does not exist.
+	pub create: bool,
+	/// If `true` and if the last component of the path is a symbolic link, path resolution
+	/// follows it.
+	pub follow_link: bool,
+}
+
+impl<'s> ResolutionSettings<'s> {
+	/// Kernel access, following symbolic links.
+	pub const fn kernel_follow() -> Self {
+		Self {
+			root: FileLocation::root(),
+			start: FileLocation::root(),
+
+			access_profile: &AccessProfile::KERNEL,
+
+			create: false,
+			follow_link: true,
+		}
+	}
+
+	/// Kernel access, without following symbolic links.
+	pub const fn kernel_nofollow() -> Self {
+		Self {
+			follow_link: false,
+			..Self::kernel_follow()
+		}
+	}
+
+	/// Returns the default for the given process.
+	///
+	/// `follow_links` tells whether symbolic links are followed.
+	pub fn for_process(proc: &'s Process, follow_links: bool) -> Self {
+		Self {
+			root: proc.chroot.clone(),
+			start: proc.cwd.1.clone(),
+
+			access_profile: &proc.access_profile,
+
+			create: false,
+			follow_link: follow_links,
+		}
+	}
+}
+
+/// The resolute of the path resolution operation.
+pub enum Resolved<'s> {
+	/// The file has been found.
+	Found(Arc<Mutex<File>>),
+	/// The file can be created.
+	///
+	/// This variant can be returned only if the `create` field is set to `true` in
+	/// [`ResolutionSettings`].
+	Creatable {
+		/// The parent directory in which the file is to be created.
+		parent: Arc<Mutex<File>>,
+		/// The name of the file to be created.
+		name: &'s [u8],
+	},
+}
+
+/// Implementation of [`resolve_path`].
+///
+/// `symlink_rec` is the number of recursions due to symbolic links resolution.
+fn resolve_path_impl<'p>(
+	path: &'p Path,
+	settings: &ResolutionSettings,
+	symlink_rec: usize,
+) -> EResult<Resolved<'p>> {
+	// Get start file
+	let start = if path.is_absolute() {
+		&settings.root
+	} else {
+		&settings.start
+	};
+	let mut file_mutex = get_file_from_location(start)?;
+	// Iterate on components
+	let mut iter = path.components().peekable();
+	for comp in &mut iter {
+		// If this is the last component
+		let is_last = iter.peek().is_none();
+		let file = file_mutex.lock();
+		// Get the name of the next entry
+		let name = match comp {
+			Component::ParentDir if file.get_location() != &settings.root => b"..",
+			Component::Normal(name) => name,
+			// Ignore
+			_ => continue,
+		};
+		match file.get_content() {
+			FileContent::Directory(entries) => {
+				// Check permission
+				if !settings.access_profile.can_search_directory(&file) {
+					return Err(errno!(EACCES));
+				}
+				let Some(entry) = entries.get(name) else {
+					// If the last component does not exist and if the file may be created
+					let res = if is_last && settings.create {
+						Ok(Resolved::Creatable {
+							parent: file_mutex,
+							name,
+						})
+					} else {
+						Err(errno!(ENOENT))
+					};
+					return res;
+				};
+				let mountpoint_id = file
+					.location
+					.get_mountpoint_id()
+					.ok_or_else(|| errno!(ENOENT))?;
+				// The location on the current filesystem
+				let mut loc = FileLocation::Filesystem {
+					mountpoint_id,
+					inode: entry.inode,
+				};
+				// Update location if on a different filesystem
+				if let Some(mountpoint) = mountpoint::from_location(&loc) {
+					let mp = mountpoint.lock();
+					let mut io = mp.get_source().get_io()?.lock();
+					let fs = mp.get_filesystem().lock();
+					loc = FileLocation::Filesystem {
+						mountpoint_id: mp.get_id(),
+						inode: fs.get_root_inode(&mut *io)?,
+					};
+				}
+				file_mutex = get_file_from_location(&loc)?;
+			}
+			// Follow link, if enabled
+			FileContent::Link(link_path) if !is_last || settings.follow_link => {
+				// If too many recursions occur, error
+				if symlink_rec + 1 > limits::SYMLOOP_MAX {
+					return Err(errno!(ELOOP));
+				}
+				// Resolve link
+				let rs = ResolutionSettings {
+					root: settings.root.clone(),
+					start: file.get_location().clone(),
+					access_profile: &settings.access_profile,
+					create: false,
+					follow_link: true,
+				};
+				let resolved = resolve_path_impl(link_path, &rs, symlink_rec + 1)?;
+				let Resolved::Found(f) = resolved else {
+					// Because `create` is set to `false`
+					unreachable!();
+				};
+				file_mutex = f;
+			}
+			_ => return Err(errno!(ENOTDIR)),
+		}
+	}
+	Ok(Resolved::Found(file_mutex))
+}
+
+/// Resolves the given `path` with the given `settings`.
+///
+/// The following conditions can cause errors:
+/// - If the path is empty, the function returns [`errno::ENOMEM`].
+/// - If a component of the path cannot be accessed with the provided access profile, the function
+///   returns [`errno::EACCES`].
+/// - If a component of the path (excluding the last) is not a directory nor a symbolic link, the
+///   function returns [`errno::ENOTDIR`].
+/// - If a component of the path (excluding the last) is a symbolic link and following them is
+///   disabled, the function returns [`errno::ENOTDIR`].
+/// - If the resolution of the path requires more symbolic link indirections than
+///   [`limits::SYMLOOP_MAX`], the function returns [`errno::ELOOP`].
+pub fn resolve_path<'p>(path: &'p Path, settings: &ResolutionSettings) -> EResult<Resolved<'p>> {
+	// Required by POSIX
+	if path.is_empty() {
+		return Err(errno!(ENOENT));
+	}
+	resolve_path_impl(path, settings, 0)
+}
+
+/// Updates the location of the file `file` according to the given mountpoint
+/// `mountpoint`.
+///
+/// If the file in not located on a filesystem, the function does nothing.
+fn update_location(file: &mut File, mountpoint: &MountPoint) {
+	if let FileLocation::Filesystem {
+		mountpoint_id, ..
+	} = &mut file.location
+	{
+		*mountpoint_id = mountpoint.get_id();
+	}
+}
+
+/// Like [`get_file_from_path`], but returns `None` is the file does not exist.
+pub fn get_file_from_path_opt(
+	path: &Path,
+	resolution_settings: &ResolutionSettings,
+) -> EResult<Option<Arc<Mutex<File>>>> {
+	let file = match resolve_path(path, resolution_settings)? {
+		Resolved::Found(file) => Some(file),
+		_ => None,
+	};
+	Ok(file)
+}
+
+/// Returns the file at the given `path`.
+///
+/// If the file does not exist, the function returns [`ENOENT`].
+pub fn get_file_from_path(
+	path: &Path,
+	resolution_settings: &ResolutionSettings,
+) -> EResult<Arc<Mutex<File>>> {
+	get_file_from_path_opt(path, resolution_settings)?.ok_or_else(|| errno!(ENOENT))
 }
 
 /// Creates a file, adds it to the VFS, then returns it. The file will be

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -131,10 +131,10 @@ pub struct ResolutionSettings {
 
 impl ResolutionSettings {
 	/// Kernel access, following symbolic links.
-	pub const fn kernel_follow() -> Self {
+	pub fn kernel_follow() -> Self {
 		Self {
-			root: FileLocation::root(),
-			start: FileLocation::root(),
+			root: mountpoint::root_location(),
+			start: mountpoint::root_location(),
 
 			access_profile: AccessProfile::KERNEL,
 
@@ -144,7 +144,7 @@ impl ResolutionSettings {
 	}
 
 	/// Kernel access, without following symbolic links.
-	pub const fn kernel_nofollow() -> Self {
+	pub fn kernel_nofollow() -> Self {
 		Self {
 			follow_link: false,
 			..Self::kernel_follow()
@@ -242,13 +242,11 @@ fn resolve_path_impl<'p>(
 				// Update location if on a different filesystem
 				if let Some(mp) = mountpoint::from_location(&loc) {
 					let mp = mp.lock();
-					let io_mutex = mp.get_source().get_io()?;
-					let mut io = io_mutex.lock();
 					let fs_mutex = mp.get_filesystem();
 					let fs = fs_mutex.lock();
 					loc = FileLocation::Filesystem {
 						mountpoint_id: mp.get_id(),
-						inode: fs.get_root_inode(&mut *io)?,
+						inode: fs.get_root_inode(),
 					};
 				}
 				get_file_from_location(&loc)?

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -10,7 +10,7 @@ use crate::file::buffer;
 use crate::file::mapping;
 use crate::file::mountpoint;
 use crate::file::open_file::OpenFile;
-use crate::file::path::Path;
+use crate::file::path::{Component, Path};
 use crate::file::perm;
 use crate::file::perm::AccessProfile;
 use crate::file::File;
@@ -27,6 +27,144 @@ use crate::util::TryClone;
 use core::ptr::NonNull;
 
 // TODO implement and use cache
+
+/// The start position for a path resolution operation.
+///
+/// **Note**: if the path to resolve is absolute, this data is ignored.
+pub enum ResolutionStart<'s> {
+	/// Start resolution from the given path. This is usually the current working directory of the
+	/// process.
+	Path(&'s Path),
+	/// Start resolution from the given location. This is usually the `fd` argument in `*at`-style
+	/// system calls.
+	///
+	/// This variant overrides the root location.
+	Location(FileLocation),
+}
+
+/// Settings for a path resolution operation.
+pub struct ResolutionSettings<'s> {
+	/// The location of the root directory for the operation.
+	pub root: FileLocation,
+	/// The beginning position of the path resolution.
+	pub start: ResolutionStart<'s>,
+
+	/// The access profile to use for resolution.
+	pub access_profile: &'s AccessProfile,
+
+	/// If `true`, the path is resolved for creation, meaning the operation will not fail if the
+	/// file does not exist.
+	pub create: bool,
+	/// If `true`, path resolution follows symbolic links.
+	pub follow_links: bool,
+	/// If `true`, path resolution enters other mountpoints than the one it started with.
+	pub follow_mountpoints: bool,
+}
+
+/// The resolute of the path resolution operation.
+pub enum ResolvedPath<'s> {
+	/// The file has been found.
+	Found(Arc<Mutex<File>>),
+	/// The file can be created.
+	///
+	/// This variant can be returned only if the `create` field is set to `true` in
+	/// [`ResolutionSettings`].
+	Creatable {
+		/// The location of the parent directory in which the file is to be created.
+		parent_location: FileLocation,
+		/// The name of the file to be created.
+		name: &'s [u8],
+	},
+}
+
+/// Resolves the given `path` with the given `settings`.
+///
+/// The following conditions can cause errors:
+/// - If the path is empty, the function returns [`errno::ENOMEM`].
+/// - If a component of the path cannot be accessed with the provided access profile, the function
+///   returns [`errno::EACCES`].
+/// - If a component of the path (excluding the last) is not a directory nor a symbolic link, the
+///   function returns [`errno::ENOTDIR`].
+/// - If a component of the path (excluding the last) is a symbolic link and following them is
+///   disabled, the function returns [`errno::ENOTDIR`].
+/// - If the resolution of the path requires more symbolic link indirections than
+///   [`limits::SYMLOOP_MAX`], the function returns [`errno::ELOOP`].
+fn resolve_path<'p>(path: &'p Path, settings: &ResolutionSettings) -> EResult<ResolvedPath<'p>> {
+	// Required by POSIX
+	if path.is_empty() {
+		return Err(errno!(ENOENT));
+	}
+
+	// Get start file
+	let start = if path.is_absolute() {
+		&settings.root
+	} else {
+		match &settings.start {
+			ResolutionStart::Path(path) => {
+				// TODO chain paths?
+				todo!()
+			}
+			ResolutionStart::Location(loc) => loc,
+		}
+	};
+	let mut file_mutex = get_file_by_location(start)?;
+
+	// Iterate on components
+	let iter = path.components();
+	for comp in iter {
+		let name = match comp {
+			Component::ParentDir => b"..",
+			Component::Normal(name) => name,
+			// Ignore
+			Component::RootDir | Component::CurDir => continue,
+		};
+		let file = file_mutex.lock();
+		match file.get_content() {
+			FileContent::Directory(entries) => {
+				// Check permission
+				if !settings.access_profile.can_search_directory(&file) {
+					return Err(errno!(EACCES));
+				}
+				let Some(entry) = entries.get(name) else {
+					// If this is the last component
+					let is_last = iter.peek().is_none();
+					// If the last component does not exist and the file may be created
+					let res = if is_last && settings.create {
+						Ok(ResolvedPath::Creatable {
+							parent_location: file.location.clone(),
+							name,
+						})
+					} else {
+						Err(errno!(ENOENT))
+					};
+					return res;
+				};
+				let mountpoint_id = file
+					.location
+					.get_mountpoint_id()
+					.ok_or_else(|| errno!(ENOENT))?;
+				// The location on the current filesystem
+				let loc = FileLocation::Filesystem {
+					mountpoint_id,
+					inode: entry.inode,
+				};
+				// TODO get mountpoint by FileLocation
+				// TODO if the mountpoint is different than the previous and mountpoint traversal
+				// is disabled, return an error TODO change loc according to the mountpoint if
+				// different
+				file_mutex = get_file_by_location(&loc)?;
+			}
+			// Follow link, if enabled
+			FileContent::Link(link_path) if settings.follow_links => {
+				// TODO resolve link
+				todo!()
+			}
+			_ => return Err(errno!(ENOTDIR)),
+		}
+	}
+
+	Ok(ResolvedPath::Found(file_mutex))
+}
 
 /// Updates the location of the file `file` according to the given mountpoint
 /// `mountpoint`.

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -329,7 +329,7 @@ pub fn get_file_from_path_opt(
 
 /// Returns the file at the given `path`.
 ///
-/// If the file does not exist, the function returns [`ENOENT`].
+/// If the file does not exist, the function returns [`errno::ENOENT`].
 pub fn get_file_from_path(
 	path: &Path,
 	resolution_settings: &ResolutionSettings,

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -4,7 +4,6 @@
 //! To manipulate files, the VFS should be used instead of
 //! calling the filesystems' functions directly.
 
-use crate::{errno, limits};
 use crate::errno::EResult;
 use crate::file::buffer;
 use crate::file::mapping;
@@ -24,6 +23,7 @@ use crate::util::container::string::String;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use crate::util::TryClone;
+use crate::{errno, limits};
 use core::ptr::NonNull;
 
 // TODO implement and use cache
@@ -346,7 +346,8 @@ pub fn create_file(
 /// - `name` is the name of the link
 /// - `ap` is the access profile to check permissions
 ///
-/// If the number of links to the file is larger than [`limits::LINK_MAX`], the function returns an error.
+/// If the number of links to the file is larger than [`limits::LINK_MAX`], the function returns an
+/// error.
 pub fn create_link(
 	target: &mut File,
 	parent: &File,

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -5,7 +5,7 @@
 //! calling the filesystems' functions directly.
 
 use crate::errno::EResult;
-use crate::file::buffer;
+use crate::file::fs::Filesystem;
 use crate::file::mapping;
 use crate::file::mountpoint;
 use crate::file::open_file::OpenFile;
@@ -18,8 +18,10 @@ use crate::file::FileLocation;
 use crate::file::FileType;
 use crate::file::Mode;
 use crate::file::MountPoint;
+use crate::file::{buffer, DeferredRemove, INode};
 use crate::process::Process;
 use crate::util::container::string::String;
+use crate::util::io::IO;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use crate::util::TryClone;
@@ -27,6 +29,36 @@ use crate::{errno, limits};
 use core::ptr::NonNull;
 
 // TODO implement and use cache
+
+/// Helper function for filesystem I/O. Provides mountpoint, I/O interface and filesystem handle
+/// for the given location.
+///
+/// If `write` is set to `true`, the function checks the filesystem is not mounted in read-only. If
+/// mounted in read-only, the function returns [`errno::EROFS`].
+fn op<F, R>(loc: &FileLocation, write: bool, f: F) -> EResult<R>
+where
+	F: FnOnce(&MountPoint, &mut dyn IO, &mut dyn Filesystem) -> EResult<R>,
+{
+	// Get the mountpoint
+	let mp_mutex = loc.get_mountpoint().ok_or_else(|| errno!(ENOENT))?;
+	let mp = mp_mutex.lock();
+	if write && mp.is_readonly() {
+		return Err(errno!(EROFS));
+	}
+
+	// Get the IO interface
+	let io_mutex = mp.get_source().get_io()?;
+	let mut io = io_mutex.lock();
+
+	// Get the filesystem
+	let fs_mutex = mp.get_filesystem();
+	let mut fs = fs_mutex.lock();
+	if write && fs.is_readonly() {
+		return Err(errno!(EROFS));
+	}
+
+	f(&mp, &mut *io, &mut *fs)
+}
 
 /// Returns the file corresponding to the given location `location`.
 ///
@@ -40,19 +72,19 @@ pub fn get_file_from_location(location: &FileLocation) -> EResult<Arc<Mutex<File
 			inode, ..
 		} => {
 			// Get the mountpoint
-			let mountpoint_mutex = location.get_mountpoint().ok_or_else(|| errno!(ENOENT))?;
-			let mountpoint = mountpoint_mutex.lock();
+			let mp_mutex = location.get_mountpoint().ok_or_else(|| errno!(ENOENT))?;
+			let mp = mp_mutex.lock();
 
 			// Get the IO interface
-			let io_mutex = mountpoint.get_source().get_io()?;
+			let io_mutex = mp.get_source().get_io()?;
 			let mut io = io_mutex.lock();
 
 			// Get the filesystem
-			let fs_mutex = mountpoint.get_filesystem();
+			let fs_mutex = mp.get_filesystem();
 			let mut fs = fs_mutex.lock();
 
 			let mut file = fs.load_file(&mut *io, *inode, String::new())?;
-			update_location(&mut file, &mountpoint);
+			update_location(&mut file, &mp);
 
 			Ok(Arc::new(Mutex::new(file))?)
 		}
@@ -207,8 +239,8 @@ fn resolve_path_impl<'p>(
 					inode: entry.inode,
 				};
 				// Update location if on a different filesystem
-				if let Some(mountpoint) = mountpoint::from_location(&loc) {
-					let mp = mountpoint.lock();
+				if let Some(mp) = mountpoint::from_location(&loc) {
+					let mp = mp.lock();
 					let mut io = mp.get_source().get_io()?.lock();
 					let fs = mp.get_filesystem().lock();
 					loc = FileLocation::Filesystem {
@@ -269,12 +301,12 @@ pub fn resolve_path<'p>(path: &'p Path, settings: &ResolutionSettings) -> EResul
 /// `mountpoint`.
 ///
 /// If the file in not located on a filesystem, the function does nothing.
-fn update_location(file: &mut File, mountpoint: &MountPoint) {
+fn update_location(file: &mut File, mp: &MountPoint) {
 	if let FileLocation::Filesystem {
 		mountpoint_id, ..
 	} = &mut file.location
 	{
-		*mountpoint_id = mountpoint.get_id();
+		*mountpoint_id = mp.get_id();
 	}
 }
 
@@ -333,27 +365,7 @@ pub fn create_file(
 		return Err(errno!(EACCES));
 	}
 
-	// Get the mountpoint
-	let mountpoint_mutex = parent
-		.location
-		.get_mountpoint()
-		.ok_or_else(|| errno!(ENOENT))?;
-	let mountpoint = mountpoint_mutex.lock();
-	if mountpoint.is_readonly() {
-		return Err(errno!(EROFS));
-	}
-
-	// Get the IO interface
-	let io_mutex = mountpoint.get_source().get_io()?;
-	let mut io = io_mutex.lock();
-
-	// Get the filesystem
-	let fs_mutex = mountpoint.get_filesystem();
-	let mut fs = fs_mutex.lock();
-	if fs.is_readonly() {
-		return Err(errno!(EROFS));
-	}
-
+	let parent_inode = parent.location.get_inode();
 	let uid = ap.get_euid();
 	let gid = if parent.get_mode() & perm::S_ISGID != 0 {
 		// If SGID is set, the newly created file shall inherit the group ID of the
@@ -363,16 +375,15 @@ pub fn create_file(
 		ap.get_egid()
 	};
 
-	// Add the file to the filesystem
-	let parent_inode = parent.location.get_inode();
-	let mut file = fs.add_file(&mut *io, parent_inode, name, uid, gid, mode, content)?;
-
+	let mut file = op(&parent.location, true, |mp, io, fs| {
+		let mut file = fs.add_file(&mut *io, parent_inode, name, uid, gid, mode, content)?;
+		update_location(&mut file, &mp);
+		Ok(file)
+	})?;
 	// Add the file to the parent's entries
 	file.set_parent_path(parent.get_path()?);
 	parent.add_entry(file.get_name().try_clone()?, file.as_dir_entry())?;
 
-	drop(fs);
-	update_location(&mut file, &mountpoint);
 	Ok(Arc::new(Mutex::new(file))?)
 }
 
@@ -416,36 +427,44 @@ pub fn create_link(
 		return Err(errno!(EACCES));
 	}
 
-	// Get the mountpoint
-	let mountpoint_mutex = target
-		.location
-		.get_mountpoint()
-		.ok_or_else(|| errno!(ENOENT))?;
-	let mountpoint = mountpoint_mutex.lock();
-	if mountpoint.is_readonly() {
-		return Err(errno!(EROFS));
+	op(&target.location, true, |mp, io, fs| {
+		fs.add_link(
+			&mut *io,
+			parent.location.get_inode(),
+			name,
+			target.location.get_inode(),
+		)?;
+		target.set_hard_links_count(target.get_hard_links_count() + 1);
+		Ok(())
+	})
+}
+
+fn remove_file_impl(
+	mp: &MountPoint,
+	io: &mut dyn IO,
+	fs: &mut dyn Filesystem,
+	parent_inode: INode,
+	name: &[u8],
+) -> EResult<()> {
+	let (links_left, inode) = fs.remove_file(&mut *io, parent_inode, name)?;
+	if links_left == 0 {
+		// If the file is a named pipe or socket, free its now unused buffer
+		let loc = FileLocation::Filesystem {
+			mountpoint_id: mp.get_id(),
+			inode,
+		};
+		buffer::release(&loc);
 	}
-
-	// Get the IO interface
-	let io_mutex = mountpoint.get_source().get_io()?;
-	let mut io = io_mutex.lock();
-
-	// Get the filesystem
-	let fs_mutex = mountpoint.get_filesystem();
-	let mut fs = fs_mutex.lock();
-	if fs.is_readonly() {
-		return Err(errno!(EROFS));
-	}
-
-	fs.add_link(
-		&mut *io,
-		parent.location.get_inode(),
-		name,
-		target.location.get_inode(),
-	)?;
-	target.set_hard_links_count(target.get_hard_links_count() + 1);
-
 	Ok(())
+}
+
+/// Removes a file without checking permissions.
+///
+/// This is useful for deferred remove since permissions have already been checked before.
+pub fn remove_file_unchecked(parent: &FileLocation, name: &[u8]) -> EResult<()> {
+	op(parent, true, |mp, io, fs| {
+		remove_file_impl(mp, io, fs, parent.get_inode(), name)
+	})
 }
 
 /// Removes a file.
@@ -469,56 +488,44 @@ pub fn remove_file(parent: &mut File, name: &[u8], ap: &AccessProfile) -> EResul
 		return Err(errno!(EACCES));
 	}
 
-	// Get the mountpoint
-	let mountpoint_mutex = parent
-		.location
-		.get_mountpoint()
-		.ok_or_else(|| errno!(ENOENT))?;
-	let mountpoint = mountpoint_mutex.lock();
-	if mountpoint.is_readonly() {
-		return Err(errno!(EROFS));
-	}
+	op(parent.get_location(), true, |mp, io, fs| {
+		// Get the file
+		let mut file = fs.load_file(&mut *io, parent.location.get_inode(), name.try_into()?)?;
 
-	// Get the IO interface
-	let io_mutex = mountpoint.get_source().get_io()?;
-	let mut io = io_mutex.lock();
+		// Check permission
+		let has_sticky_bit = parent.mode & S_ISVTX != 0;
+		if has_sticky_bit && ap.get_euid() != file.get_uid() && ap.get_euid() != parent.get_uid() {
+			return Err(errno!(EACCES));
+		}
+		// If the file to remove is a mountpoint, error
+		if file.is_mountpoint() {
+			return Err(errno!(EBUSY));
+		}
 
-	// Get the filesystem
-	let fs_mutex = mountpoint.get_filesystem();
-	let mut fs = fs_mutex.lock();
-	if fs.is_readonly() {
-		return Err(errno!(EROFS));
-	}
+		// Defer remove if the file is in use
+		let last_link = file.get_hard_links_count() == 1;
+		let symlink = file.get_type() == FileType::Link;
+		let defer = last_link && !symlink && OpenFile::is_open(&file.location);
 
-	// Get the file
-	let mut file = fs.load_file(&mut *io, parent.location.get_inode(), name.try_into()?)?;
+		if defer {
+			file.defer_remove(DeferredRemove {
+				parent: parent.location.clone(),
+				name: name.try_into()?,
+			});
+		} else {
+			remove_file_impl(mp, io, fs, parent.location.get_inode(), name)?;
+		}
+		Ok(())
+	})
+}
 
-	// Check permission
-	let has_sticky_bit = parent.mode & S_ISVTX != 0;
-	if has_sticky_bit && ap.get_euid() != file.get_uid() && ap.get_euid() != parent.get_uid() {
-		return Err(errno!(EACCES));
-	}
-	// If the file to remove is a mountpoint, error
-	if mountpoint::from_location(file.get_location()).is_some() {
-		return Err(errno!(EBUSY));
-	}
-
-	// Defer remove if the file is in use
-	let last_link = file.get_hard_links_count() == 1;
-	let symlink = file.get_type() == FileType::Link;
-	if last_link && !symlink && OpenFile::is_open(&file.location) {
-		file.defer_remove();
-		return Ok(());
-	}
-
-	// Remove the file
-	let links_left = fs.remove_file(&mut *io, parent.location.get_inode(), name)?;
-	if links_left == 0 {
-		// If the file is a named pipe or socket, free its now unused buffer
-		buffer::release(&file.location);
-	}
-
-	Ok(())
+/// TODO doc
+pub fn remove_file_from_path(
+	path: &Path,
+	resolution_settings: &ResolutionSettings,
+) -> EResult<()> {
+	// TODO
+	todo!()
 }
 
 /// Maps the page at offset `off` in the file at location `loc`.

--- a/src/file/vfs.rs
+++ b/src/file/vfs.rs
@@ -4,21 +4,21 @@
 //! To manipulate files, the VFS should be used instead of
 //! calling the filesystems' functions directly.
 
+use super::fs::Filesystem;
+use super::mapping;
+use super::mountpoint;
+use super::open_file::OpenFile;
+use super::path::{Component, Path};
+use super::perm;
+use super::perm::{AccessProfile, S_ISVTX};
+use super::File;
+use super::FileContent;
+use super::FileLocation;
+use super::FileType;
+use super::Mode;
+use super::MountPoint;
+use super::{buffer, DeferredRemove, INode};
 use crate::errno::EResult;
-use crate::file::fs::Filesystem;
-use crate::file::mapping;
-use crate::file::mountpoint;
-use crate::file::open_file::OpenFile;
-use crate::file::path::{Component, Path};
-use crate::file::perm;
-use crate::file::perm::{AccessProfile, S_ISVTX};
-use crate::file::File;
-use crate::file::FileContent;
-use crate::file::FileLocation;
-use crate::file::FileType;
-use crate::file::Mode;
-use crate::file::MountPoint;
-use crate::file::{buffer, DeferredRemove, INode};
 use crate::process::Process;
 use crate::util::container::string::String;
 use crate::util::io::IO;
@@ -519,13 +519,16 @@ pub fn remove_file(parent: &mut File, name: &[u8], ap: &AccessProfile) -> EResul
 	})
 }
 
-/// TODO doc
+/// Helper function to remove a file from a given `path`.
 pub fn remove_file_from_path(
 	path: &Path,
 	resolution_settings: &ResolutionSettings,
 ) -> EResult<()> {
-	// TODO
-	todo!()
+	let file_name = path.file_name().ok_or_else(|| errno!(ENOENT))?;
+	let parent = path.parent().ok_or_else(|| errno!(ENOENT))?;
+	let parent = get_file_from_path(parent, resolution_settings)?;
+	let parent = parent.lock();
+	remove_file(&mut *parent, file_name, &resolution_settings.access_profile)
 }
 
 /// Maps the page at offset `off` in the file at location `loc`.

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -33,6 +33,7 @@
 #![feature(trusted_len)]
 #![feature(unsize)]
 #![feature(once_cell_try)]
+#![feature(iter_intersperse)]
 #![deny(warnings)]
 #![allow(unused_attributes)]
 #![allow(dead_code)]

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -79,7 +79,6 @@ pub mod util;
 use crate::errno::EResult;
 use crate::file::fs::initramfs;
 use crate::file::path::Path;
-use crate::file::perm::AccessProfile;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::logger::LOGGER;
@@ -212,12 +211,14 @@ fn init(init_path: String) -> EResult<()> {
 		b"TERM=maestro".try_into()?,
 	]?;
 
+	let rs = ResolutionSettings::kernel_follow();
+
 	let path = Path::new(&init_path)?;
-	let file_mutex = vfs::get_file_from_path(path, &ResolutionSettings::default())?;
+	let file_mutex = vfs::get_file_from_path(path, &rs)?;
 	let mut file = file_mutex.lock();
 
 	let exec_info = ExecInfo {
-		access_profile: AccessProfile::KERNEL,
+		path_resolution: &rs,
 		argv: vec![init_path]?,
 		envp: env,
 	};

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -205,8 +205,6 @@ pub fn bind_vmem() {
 ///
 /// `init_path` is the path to the init program.
 fn init(init_path: String) -> EResult<()> {
-	let path = Path::from_str(&init_path, true)?;
-
 	let proc_mutex = Process::new()?;
 	let mut proc = proc_mutex.lock();
 
@@ -216,7 +214,8 @@ fn init(init_path: String) -> EResult<()> {
 		b"TERM=maestro".try_into()?,
 	]?;
 
-	let file_mutex = vfs::get_file_from_path(&path, &AccessProfile::KERNEL, true)?;
+	let path = Path::new(&init_path)?;
+	let file_mutex = vfs::get_file_from_path(path, &AccessProfile::KERNEL, true)?;
 	let mut file = file_mutex.lock();
 
 	let exec_info = ExecInfo {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -81,6 +81,7 @@ use crate::file::fs::initramfs;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::logger::LOGGER;
 use crate::memory::vmem;
 use crate::memory::vmem::VMem;
@@ -205,9 +206,6 @@ pub fn bind_vmem() {
 ///
 /// `init_path` is the path to the init program.
 fn init(init_path: String) -> EResult<()> {
-	let proc_mutex = Process::new()?;
-	let mut proc = proc_mutex.lock();
-
 	// The initial environment
 	let env: Vec<String> = vec![
 		b"PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin".try_into()?,
@@ -215,7 +213,7 @@ fn init(init_path: String) -> EResult<()> {
 	]?;
 
 	let path = Path::new(&init_path)?;
-	let file_mutex = vfs::get_file_from_path(path, &AccessProfile::KERNEL, true)?;
+	let file_mutex = vfs::get_file_from_path(path, &ResolutionSettings::default())?;
 	let mut file = file_mutex.lock();
 
 	let exec_info = ExecInfo {
@@ -225,6 +223,8 @@ fn init(init_path: String) -> EResult<()> {
 	};
 	let program_image = exec::build_image(&mut file, exec_info)?;
 
+	let proc_mutex = Process::new()?;
+	let mut proc = proc_mutex.lock();
 	exec::exec(&mut proc, program_image)
 }
 

--- a/src/process/exec/elf.rs
+++ b/src/process/exec/elf.rs
@@ -13,6 +13,7 @@ use crate::exec::vdso::MappedVDSO;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::memory;
 use crate::memory::vmem;
@@ -598,8 +599,10 @@ impl ELFExecutor {
 
 			// Get file
 			let interp_path = Path::new(interp_path)?;
-			let interp_file_mutex =
-				vfs::get_file_from_path(&interp_path, &self.info.access_profile, true)?;
+			let interp_file_mutex = vfs::get_file_from_path(
+				&interp_path,
+				&ResolutionSettings::simple(&self.info.access_profile, true),
+			)?;
 			let mut interp_file = interp_file_mutex.lock();
 
 			let interp_image = read_exec_file(&mut interp_file, &self.info.access_profile)?;

--- a/src/process/exec/elf.rs
+++ b/src/process/exec/elf.rs
@@ -596,9 +596,8 @@ impl ELFExecutor {
 				return Err(errno!(EINVAL));
 			}
 
-			let interp_path = Path::from_str(interp_path, true)?;
-
-			// Getting file
+			// Get file
+			let interp_path = Path::new(interp_path)?;
 			let interp_file_mutex =
 				vfs::get_file_from_path(&interp_path, &self.info.access_profile, true)?;
 			let mut interp_file = interp_file_mutex.lock();

--- a/src/process/exec/elf.rs
+++ b/src/process/exec/elf.rs
@@ -286,7 +286,7 @@ impl<'s> ELFExecutor<'s> {
 	/// Arguments:
 	/// - `uid` is the User ID of the executing user.
 	/// - `gid` is the Group ID of the executing user.
-	pub fn new(info: ExecInfo) -> Result<Self, Errno> {
+	pub fn new(info: ExecInfo<'s>) -> EResult<Self> {
 		Ok(Self {
 			info,
 		})
@@ -599,7 +599,7 @@ impl<'s> ELFExecutor<'s> {
 			// Get file
 			let interp_path = Path::new(interp_path)?;
 			let interp_file_mutex =
-				vfs::get_file_from_path(&interp_path, &self.info.path_resolution)?;
+				vfs::get_file_from_path(interp_path, self.info.path_resolution)?;
 			let mut interp_file = interp_file_mutex.lock();
 
 			let interp_image =

--- a/src/process/exec/elf.rs
+++ b/src/process/exec/elf.rs
@@ -598,13 +598,12 @@ impl<'s> ELFExecutor<'s> {
 
 			// Get file
 			let interp_path = Path::new(interp_path)?;
-			let interp_file_mutex = vfs::get_file_from_path(
-				&interp_path,
-				&self.info.path_resolution,
-			)?;
+			let interp_file_mutex =
+				vfs::get_file_from_path(&interp_path, &self.info.path_resolution)?;
 			let mut interp_file = interp_file_mutex.lock();
 
-			let interp_image = read_exec_file(&mut interp_file, &self.info.path_resolution.access_profile)?;
+			let interp_image =
+				read_exec_file(&mut interp_file, &self.info.path_resolution.access_profile)?;
 			let interp_elf = ELFParser::new(interp_image.as_slice())?;
 			let i_load_base = load_end as _; // TODO ASLR
 			let load_info = self.load_elf(&interp_elf, mem_space, i_load_base, true)?;

--- a/src/process/exec/elf.rs
+++ b/src/process/exec/elf.rs
@@ -13,7 +13,6 @@ use crate::exec::vdso::MappedVDSO;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
-use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::memory;
 use crate::memory::vmem;
@@ -203,19 +202,19 @@ fn build_auxilary(
 	aux.push(AuxEntryDesc::new(AT_NOTELF, AuxEntryDescValue::Number(0)))?;
 	aux.push(AuxEntryDesc::new(
 		AT_UID,
-		AuxEntryDescValue::Number(exec_info.access_profile.get_uid() as _),
+		AuxEntryDescValue::Number(exec_info.path_resolution.access_profile.get_uid() as _),
 	))?;
 	aux.push(AuxEntryDesc::new(
 		AT_EUID,
-		AuxEntryDescValue::Number(exec_info.access_profile.get_euid() as _),
+		AuxEntryDescValue::Number(exec_info.path_resolution.access_profile.get_euid() as _),
 	))?;
 	aux.push(AuxEntryDesc::new(
 		AT_GID,
-		AuxEntryDescValue::Number(exec_info.access_profile.get_gid() as _),
+		AuxEntryDescValue::Number(exec_info.path_resolution.access_profile.get_gid() as _),
 	))?;
 	aux.push(AuxEntryDesc::new(
 		AT_EGID,
-		AuxEntryDescValue::Number(exec_info.access_profile.get_egid() as _),
+		AuxEntryDescValue::Number(exec_info.path_resolution.access_profile.get_egid() as _),
 	))?;
 	aux.push(AuxEntryDesc::new(
 		AT_PLATFORM,
@@ -276,12 +275,12 @@ fn read_exec_file(file: &mut File, ap: &AccessProfile) -> Result<Vec<u8>, Errno>
 }
 
 /// The program executor for ELF files.
-pub struct ELFExecutor {
-	/// Execution informations.
-	info: ExecInfo,
+pub struct ELFExecutor<'s> {
+	/// Execution information.
+	info: ExecInfo<'s>,
 }
 
-impl ELFExecutor {
+impl<'s> ELFExecutor<'s> {
 	/// Creates a new instance to execute the given program.
 	///
 	/// Arguments:
@@ -601,11 +600,11 @@ impl ELFExecutor {
 			let interp_path = Path::new(interp_path)?;
 			let interp_file_mutex = vfs::get_file_from_path(
 				&interp_path,
-				&ResolutionSettings::simple(&self.info.access_profile, true),
+				&self.info.path_resolution,
 			)?;
 			let mut interp_file = interp_file_mutex.lock();
 
-			let interp_image = read_exec_file(&mut interp_file, &self.info.access_profile)?;
+			let interp_image = read_exec_file(&mut interp_file, &self.info.path_resolution.access_profile)?;
 			let interp_elf = ELFParser::new(interp_image.as_slice())?;
 			let i_load_base = load_end as _; // TODO ASLR
 			let load_info = self.load_elf(&interp_elf, mem_space, i_load_base, true)?;
@@ -682,13 +681,13 @@ impl ELFExecutor {
 	}
 }
 
-impl Executor for ELFExecutor {
+impl<'s> Executor for ELFExecutor<'s> {
 	// TODO Ensure there is no way to write in kernel space (check segments position
 	// and relocations)
 	// TODO Handle suid and sgid
 	fn build_image(&self, file: &mut File) -> Result<ProgramImage, Errno> {
 		// The ELF file image
-		let image = read_exec_file(file, &self.info.access_profile)?;
+		let image = read_exec_file(file, &self.info.path_resolution.access_profile)?;
 		// Parsing the ELF file
 		let parser = ELFParser::new(image.as_slice())?;
 

--- a/src/process/exec/mod.rs
+++ b/src/process/exec/mod.rs
@@ -27,7 +27,7 @@ use core::ffi::c_void;
 /// Information to prepare a program image to be executed.
 pub struct ExecInfo<'s> {
 	/// Path resolution settings.
-	pub path_resolution: &'s ResolutionSettings<'s>,
+	pub path_resolution: &'s ResolutionSettings,
 	/// The list of arguments.
 	pub argv: Vec<String>,
 	/// The list of environment variables.

--- a/src/process/exec/mod.rs
+++ b/src/process/exec/mod.rs
@@ -11,6 +11,7 @@ pub mod vdso;
 
 use crate::errno::EResult;
 use crate::errno::Errno;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::process::mem_space::MemSpace;
 use crate::process::regs::Regs;
@@ -22,7 +23,6 @@ use crate::util::lock::IntMutex;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use core::ffi::c_void;
-use crate::file::vfs::ResolutionSettings;
 
 /// Information to prepare a program image to be executed.
 pub struct ExecInfo<'s> {

--- a/src/process/exec/mod.rs
+++ b/src/process/exec/mod.rs
@@ -11,7 +11,6 @@ pub mod vdso;
 
 use crate::errno::EResult;
 use crate::errno::Errno;
-use crate::file::perm::AccessProfile;
 use crate::file::File;
 use crate::process::mem_space::MemSpace;
 use crate::process::regs::Regs;
@@ -23,11 +22,12 @@ use crate::util::lock::IntMutex;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use core::ffi::c_void;
+use crate::file::vfs::ResolutionSettings;
 
-/// Informations to prepare a program image to be executed.
-pub struct ExecInfo {
-	/// The access profile of the calling agent.
-	pub access_profile: AccessProfile,
+/// Information to prepare a program image to be executed.
+pub struct ExecInfo<'s> {
+	/// Path resolution settings.
+	pub path_resolution: &'s ResolutionSettings<'s>,
 	/// The list of arguments.
 	pub argv: Vec<String>,
 	/// The list of environment variables.

--- a/src/process/mem_space/mapping.rs
+++ b/src/process/mem_space/mapping.rs
@@ -496,7 +496,7 @@ impl MemMapping {
 		else {
 			return Ok(());
 		};
-		let Ok(file_mutex) = vfs::get_file_by_location(location) else {
+		let Ok(file_mutex) = vfs::get_file_from_location(location) else {
 			return Ok(());
 		};
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -495,7 +495,7 @@ impl Process {
 			let mut fds_table = FileDescriptorTable::default();
 
 			let tty_path = Path::new(TTY_DEVICE_PATH.as_bytes())?;
-			let tty_file_mutex = vfs::get_file_from_path(&tty_path, &rs)?;
+			let tty_file_mutex = vfs::get_file_from_path(tty_path, &rs)?;
 			let tty_file = tty_file_mutex.lock();
 
 			let loc = tty_file.get_location();
@@ -521,7 +521,7 @@ impl Process {
 
 			tty: tty::get(None).unwrap(), // Initialization with the init TTY
 
-			access_profile: rs.access_profile.clone(),
+			access_profile: rs.access_profile,
 			umask: DEFAULT_UMASK,
 
 			state: State::Running,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -510,6 +510,7 @@ impl Process {
 
 			fds_table
 		};
+		let root_loc = mountpoint::root_location();
 
 		let process = Self {
 			pid: pid::INIT_PID,
@@ -548,8 +549,8 @@ impl Process {
 			user_stack: None,
 			kernel_stack: None,
 
-			cwd: Arc::new((PathBuf::root(), FileLocation::root()))?,
-			chroot: FileLocation::root(),
+			cwd: Arc::new((PathBuf::root(), root_loc.clone()))?,
+			chroot: root_loc,
 			file_descriptors: Some(Arc::new(Mutex::new(file_descriptors))?),
 
 			sigmask: Bitfield::new(signal::SIGNALS_COUNT)?,

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -495,10 +495,7 @@ impl Process {
 			let mut fds_table = FileDescriptorTable::default();
 
 			let tty_path = Path::new(TTY_DEVICE_PATH.as_bytes())?;
-			let tty_file_mutex = vfs::get_file_from_path(
-				&tty_path,
-				&rs,
-			)?;
+			let tty_file_mutex = vfs::get_file_from_path(&tty_path, &rs)?;
 			let tty_file = tty_file_mutex.lock();
 
 			let loc = tty_file.get_location();

--- a/src/syscall/access.rs
+++ b/src/syscall/access.rs
@@ -6,7 +6,7 @@ use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use crate::syscall::util::at;
-use crate::syscall::util::at::{AT_EACCESS, AT_FDCWD, AT_SYMLINK_NOFOLLOW};
+use crate::syscall::util::at::{AT_EACCESS, AT_FDCWD};
 use core::ffi::c_int;
 use macros::syscall;
 
@@ -34,7 +34,6 @@ pub fn do_access(
 	flags: Option<i32>,
 ) -> Result<i32, Errno> {
 	let flags = flags.unwrap_or(0);
-	let follow_symlinks = flags & AT_SYMLINK_NOFOLLOW == 0;
 	// Use effective IDs instead of real IDs
 	let eaccess = flags & AT_EACCESS != 0;
 
@@ -42,12 +41,12 @@ pub fn do_access(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let rs = ResolutionSettings::for_process(&*proc, true);
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space_mutex = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space_mutex.lock();
 
-		let fds = proc.file_descriptors.unwrap().lock();
+		let fds = proc.file_descriptors.as_ref().unwrap().lock();
 
 		let pathname = pathname
 			.get(&mem_space_guard)?

--- a/src/syscall/access.rs
+++ b/src/syscall/access.rs
@@ -1,10 +1,9 @@
 //! The `access` system call allows to check access to a given file.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
-use crate::file::vfs;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
+use crate::syscall::util;
 use core::ffi::c_int;
 use macros::syscall;
 
@@ -58,7 +57,7 @@ pub fn do_access(
 	// Use effective IDs instead of real IDs
 	let eaccess = flags & AT_EACCESS != 0;
 
-	let (path, cwd, ap) = {
+	let (file, ap) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -68,26 +67,17 @@ pub fn do_access(
 		let pathname = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EINVAL))?;
-		let path = Path::from_str(pathname, true)?;
 
-		let cwd = proc.cwd.clone();
+		let file = util::get_file_at(
+			proc,
+			dirfd.unwrap_or(AT_FDCWD),
+			pathname,
+			follow_symlinks,
+			flags,
+		)?;
 
-		(path, cwd, proc.access_profile)
+		(file, proc.access_profile)
 	};
-
-	// Get file
-	let mut path = path;
-	if path.is_absolute() {
-		// TODO
-	} else if let Some(dirfd) = dirfd {
-		if dirfd == AT_FDCWD {
-			path = cwd.concat(&path)?;
-		} else {
-			// TODO Get file from fd and get its path to concat
-			todo!();
-		}
-	}
-	let file = vfs::get_file_from_path(&path, &ap, follow_symlinks)?;
 
 	// Do access checks
 	{

--- a/src/syscall/chdir.rs
+++ b/src/syscall/chdir.rs
@@ -20,8 +20,9 @@ pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 
-		let path_str = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let new_cwd = super::util::get_absolute_path(&proc, Path::from_str(path_str, true)?)?;
+		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
+		let path = Path::new(path)?;
+		let new_cwd = super::util::get_absolute_path(&proc, path)?;
 
 		(new_cwd, proc.access_profile)
 	};

--- a/src/syscall/chdir.rs
+++ b/src/syscall/chdir.rs
@@ -23,7 +23,6 @@ pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, rs)

--- a/src/syscall/chdir.rs
+++ b/src/syscall/chdir.rs
@@ -5,6 +5,7 @@ use crate::errno;
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -28,7 +29,7 @@ pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
 	};
 
 	{
-		let dir_mutex = vfs::get_file_from_path(&new_cwd, &ap, true)?;
+		let dir_mutex = vfs::get_file_from_path(&new_cwd, &ResolutionSettings::simple(&ap, true))?;
 		let dir = dir_mutex.lock();
 
 		// Check for errors

--- a/src/syscall/chdir.rs
+++ b/src/syscall/chdir.rs
@@ -3,7 +3,7 @@
 
 use crate::errno;
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
@@ -22,7 +22,7 @@ pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
 		let mem_space_guard = mem_space.lock();
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, rs)

--- a/src/syscall/chdir.rs
+++ b/src/syscall/chdir.rs
@@ -14,7 +14,7 @@ use macros::syscall;
 
 #[syscall]
 pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
-	let (new_cwd, ap) = {
+	let (path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -23,29 +23,32 @@ pub fn chdir(path: SyscallString) -> Result<i32, Errno> {
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let new_cwd = super::util::get_absolute_path(&proc, path)?;
+		let path = super::util::get_absolute_path(&proc, path)?;
 
-		(new_cwd, proc.access_profile)
+		let rs = ResolutionSettings::for_process(&proc, true);
+		(path, rs)
 	};
 
-	{
-		let dir_mutex = vfs::get_file_from_path(&new_cwd, &ResolutionSettings::simple(&ap, true))?;
+	let location = {
+		let dir_mutex = vfs::get_file_from_path(&path, &rs)?;
 		let dir = dir_mutex.lock();
 
 		// Check for errors
 		if dir.get_type() != FileType::Directory {
 			return Err(errno!(ENOTDIR));
 		}
-		if !ap.can_list_directory(&dir) {
+		if !rs.access_profile.can_list_directory(&dir) {
 			return Err(errno!(EACCES));
 		}
-	}
+
+		dir.get_location().clone()
+	};
 
 	// Set new cwd
 	{
 		let proc_mutex = Process::current_assert();
 		let mut proc = proc_mutex.lock();
-		proc.cwd = Arc::new(new_cwd)?;
+		proc.cwd = Arc::new((path, location))?;
 	}
 
 	Ok(0)

--- a/src/syscall/chmod.rs
+++ b/src/syscall/chmod.rs
@@ -22,7 +22,6 @@ pub fn chmod(pathname: SyscallString, mode: c_int) -> Result<i32, Errno> {
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, rs)

--- a/src/syscall/chmod.rs
+++ b/src/syscall/chmod.rs
@@ -1,7 +1,7 @@
 //! The `chmod` system call allows change the permissions on a file.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::process::mem_space::ptr::SyscallString;
@@ -21,7 +21,7 @@ pub fn chmod(pathname: SyscallString, mode: c_int) -> Result<i32, Errno> {
 		let path = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, rs)

--- a/src/syscall/chmod.rs
+++ b/src/syscall/chmod.rs
@@ -20,7 +20,7 @@ pub fn chmod(pathname: SyscallString, mode: c_int) -> Result<i32, Errno> {
 		let path = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::from_str(path, true)?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, proc.access_profile)

--- a/src/syscall/chmod.rs
+++ b/src/syscall/chmod.rs
@@ -3,6 +3,7 @@
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use core::ffi::c_int;
@@ -10,7 +11,7 @@ use macros::syscall;
 
 #[syscall]
 pub fn chmod(pathname: SyscallString, mode: c_int) -> Result<i32, Errno> {
-	let (path, ap) = {
+	let (path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -23,14 +24,15 @@ pub fn chmod(pathname: SyscallString, mode: c_int) -> Result<i32, Errno> {
 		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
-		(path, proc.access_profile)
+		let rs = ResolutionSettings::for_process(&proc, true);
+		(path, rs)
 	};
 
-	let file_mutex = vfs::get_file_from_path(&path, &ap, true)?;
+	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
 	let mut file = file_mutex.lock();
 
 	// Check permissions
-	if !ap.can_set_file_permissions(&file) {
+	if !rs.access_profile.can_set_file_permissions(&file) {
 		return Err(errno!(EPERM));
 	}
 

--- a/src/syscall/chown.rs
+++ b/src/syscall/chown.rs
@@ -2,7 +2,7 @@
 
 use crate::errno::EResult;
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -27,8 +27,10 @@ pub fn do_chown(
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space = mem_space.lock();
 
-		let path = pathname.get(&mem_space)?.ok_or_else(|| errno!(EFAULT))?;
-		(Path::from_str(path, true)?, proc.access_profile)
+		let path = pathname.get(&*mem_space)?.ok_or_else(|| errno!(EFAULT))?;
+		let path = PathBuf::try_from(path)?;
+
+		(path, proc.access_profile)
 	};
 
 	let file_mutex = vfs::get_file_from_path(&path, &ap, follow_links)?;

--- a/src/syscall/chown.rs
+++ b/src/syscall/chown.rs
@@ -28,7 +28,7 @@ pub fn do_chown(
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space = mem_space.lock();
 
-		let path = pathname.get(&*mem_space)?.ok_or_else(|| errno!(EFAULT))?;
+		let path = pathname.get(&mem_space)?.ok_or_else(|| errno!(EFAULT))?;
 		let path = PathBuf::try_from(path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, follow_links);

--- a/src/syscall/chroot.rs
+++ b/src/syscall/chroot.rs
@@ -19,8 +19,10 @@ pub fn chroot(path: SyscallString) -> Result<i32, Errno> {
 		return Err(errno!(EPERM));
 	}
 
-	let rs = ResolutionSettings::for_process(&proc, true);
-	rs.root = FileLocation::root();
+	let rs = ResolutionSettings {
+		root: FileLocation::root(),
+		..ResolutionSettings::for_process(&proc, true)
+	};
 
 	// Get file
 	let file = {
@@ -30,7 +32,7 @@ pub fn chroot(path: SyscallString) -> Result<i32, Errno> {
 		let path = path.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
 
-		vfs::get_file_from_path(&path, &rs)?
+		vfs::get_file_from_path(path, &rs)?
 	};
 	let file = file.lock();
 	if file.get_type() != FileType::Directory {

--- a/src/syscall/chroot.rs
+++ b/src/syscall/chroot.rs
@@ -4,7 +4,7 @@
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs::ResolutionSettings;
-use crate::file::{FileLocation, FileType};
+use crate::file::{mountpoint, FileType};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use crate::vfs;
@@ -20,7 +20,7 @@ pub fn chroot(path: SyscallString) -> Result<i32, Errno> {
 	}
 
 	let rs = ResolutionSettings {
-		root: FileLocation::root(),
+		root: mountpoint::root_location(),
 		..ResolutionSettings::for_process(&proc, true)
 	};
 

--- a/src/syscall/chroot.rs
+++ b/src/syscall/chroot.rs
@@ -2,10 +2,11 @@
 //! the current process.
 
 use crate::errno::Errno;
-use crate::file::path::PathBuf;
+use crate::file::path::Path;
+use crate::file::vfs::ResolutionSettings;
+use crate::file::{FileLocation, FileType};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
-use crate::util::ptr::arc::Arc;
 use crate::vfs;
 use macros::syscall;
 
@@ -18,16 +19,25 @@ pub fn chroot(path: SyscallString) -> Result<i32, Errno> {
 		return Err(errno!(EPERM));
 	}
 
-	let path = {
+	let rs = ResolutionSettings::for_process(&proc, true);
+	rs.root = FileLocation::root();
+
+	// Get file
+	let file = {
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
-		let path = path.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		PathBuf::try_from(path)?
-	};
 
-	// Check access to file
-	vfs::get_file_from_path(&path, &proc.access_profile, true)?;
-	proc.chroot = Arc::new(path)?;
+		let path = path.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
+		let path = Path::new(path)?;
+
+		vfs::get_file_from_path(&path, &rs)?
+	};
+	let file = file.lock();
+	if file.get_type() != FileType::Directory {
+		return Err(errno!(ENOTDIR));
+	}
+
+	proc.chroot = file.get_location().clone();
 
 	Ok(0)
 }

--- a/src/syscall/chroot.rs
+++ b/src/syscall/chroot.rs
@@ -2,7 +2,7 @@
 //! the current process.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use crate::util::ptr::arc::Arc;
@@ -22,7 +22,7 @@ pub fn chroot(path: SyscallString) -> Result<i32, Errno> {
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 		let path = path.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		Path::from_str(path, true)?
+		PathBuf::try_from(path)?
 	};
 
 	// Check access to file

--- a/src/syscall/execve.rs
+++ b/src/syscall/execve.rs
@@ -222,12 +222,8 @@ pub fn execve(
 	cli!();
 
 	// Build the program's image
-	let program_image = unsafe {
-		stack::switch(None, move || {
-			build_image(file, &rs, argv, envp)
-		})
-		.unwrap()?
-	};
+	let program_image =
+		unsafe { stack::switch(None, move || build_image(file, &rs, argv, envp)).unwrap()? };
 
 	// The temporary stack will not be used since the scheduler cannot be ticked when
 	// interrupts are disabled

--- a/src/syscall/execve.rs
+++ b/src/syscall/execve.rs
@@ -192,7 +192,7 @@ pub fn execve(
 			}
 
 			// Set interpreter to arguments
-			let interp = String::try_from(&shebang.buff[shebang.interp])?;
+			let interp = String::try_from(&shebang.buff[shebang.interp.clone()])?;
 			argv.insert(0, interp)?;
 
 			// Set optional argument if it exists

--- a/src/syscall/execve.rs
+++ b/src/syscall/execve.rs
@@ -3,7 +3,7 @@
 use crate::errno;
 use crate::errno::EResult;
 use crate::errno::Errno;
-use crate::file::path::{Path, PathBuf};
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
@@ -156,8 +156,7 @@ pub fn execve(
 			let path = pathname
 				.get(&mem_space_guard)?
 				.ok_or_else(|| errno!(EFAULT))?;
-			let path = Path::new(path)?;
-			super::util::get_absolute_path(&proc, path)?
+			PathBuf::try_from(path)?
 		};
 
 		let argv = unsafe { super::util::get_str_array(&proc, argv)? };

--- a/src/syscall/execve.rs
+++ b/src/syscall/execve.rs
@@ -3,7 +3,7 @@
 use crate::errno;
 use crate::errno::EResult;
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::{Path, PathBuf};
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
 use crate::file::File;
@@ -153,14 +153,12 @@ pub fn execve(
 			let mem_space = proc.get_mem_space().unwrap();
 			let mem_space_guard = mem_space.lock();
 
-			Path::from_str(
-				pathname
-					.get(&mem_space_guard)?
-					.ok_or_else(|| errno!(EFAULT))?,
-				true,
-			)?
+			let path = pathname
+				.get(&mem_space_guard)?
+				.ok_or_else(|| errno!(EFAULT))?;
+			let path = Path::new(path)?;
+			super::util::get_absolute_path(&proc, path)?
 		};
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let argv = unsafe { super::util::get_str_array(&proc, argv)? };
 		let envp = unsafe { super::util::get_str_array(&proc, envp)? };
@@ -194,7 +192,7 @@ pub fn execve(
 			}
 
 			// Set interpreter to arguments
-			let interp = String::try_from(&shebang.buff[shebang.interp.clone()])?;
+			let interp = String::try_from(&shebang.buff[shebang.interp])?;
 			argv.insert(0, interp)?;
 
 			// Set optional argument if it exists
@@ -204,7 +202,7 @@ pub fn execve(
 			}
 
 			// Set interpreter's path
-			path = Path::from_str(&shebang.buff[shebang.interp], true)?;
+			path = PathBuf::try_from(&shebang.buff[shebang.interp])?;
 
 			i += 1;
 		} else {

--- a/src/syscall/fchdir.rs
+++ b/src/syscall/fchdir.rs
@@ -50,7 +50,7 @@ pub fn fchdir(fd: c_int) -> Result<i32, Errno> {
 		let proc_mutex = Process::current_assert();
 		let mut proc = proc_mutex.lock();
 
-		let new_cwd = super::util::get_absolute_path(&proc, new_cwd)?;
+		let new_cwd = super::util::get_absolute_path(&proc, &new_cwd)?;
 		proc.cwd = Arc::new(new_cwd)?;
 	}
 

--- a/src/syscall/fchdir.rs
+++ b/src/syscall/fchdir.rs
@@ -32,7 +32,7 @@ pub fn fchdir(fd: c_int) -> Result<i32, Errno> {
 	};
 	let open_file = open_file_mutex.lock();
 
-	let new_cwd = {
+	let (path, location) = {
 		let file = open_file.get_file().lock();
 
 		// Check for errors
@@ -43,15 +43,15 @@ pub fn fchdir(fd: c_int) -> Result<i32, Errno> {
 			return Err(errno!(EACCES));
 		}
 
-		file.get_path()
-	}?;
+		(file.get_path()?.to_path_buf()?, file.get_location().clone())
+	};
 
 	{
 		let proc_mutex = Process::current_assert();
 		let mut proc = proc_mutex.lock();
 
-		let new_cwd = super::util::get_absolute_path(&proc, &new_cwd)?;
-		proc.cwd = Arc::new(new_cwd)?;
+		let path = super::util::get_absolute_path(&proc, &path)?;
+		proc.cwd = Arc::new((path, location))?;
 	}
 
 	Ok(0)

--- a/src/syscall/fchdir.rs
+++ b/src/syscall/fchdir.rs
@@ -46,13 +46,9 @@ pub fn fchdir(fd: c_int) -> Result<i32, Errno> {
 		(file.get_path()?.to_path_buf()?, file.get_location().clone())
 	};
 
-	{
-		let proc_mutex = Process::current_assert();
-		let mut proc = proc_mutex.lock();
-
-		let path = super::util::get_absolute_path(&proc, &path)?;
-		proc.cwd = Arc::new((path, location))?;
-	}
+	let proc_mutex = Process::current_assert();
+	let mut proc = proc_mutex.lock();
+	proc.cwd = Arc::new((path, location))?;
 
 	Ok(0)
 }

--- a/src/syscall/fchmodat.rs
+++ b/src/syscall/fchmodat.rs
@@ -21,7 +21,7 @@ pub fn fchmodat(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let rs = ResolutionSettings::for_process(&*proc, true);
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
@@ -38,7 +38,7 @@ pub fn fchmodat(
 
 	let fds = fds_mutex.lock();
 
-	let Resolved::Found(file_mutex) = at::get_file(&fds, rs, dirfd, &path, flags)? else {
+	let Resolved::Found(file_mutex) = at::get_file(&fds, rs.clone(), dirfd, &path, flags)? else {
 		return Err(errno!(ENOENT));
 	};
 	let mut file = file_mutex.lock();

--- a/src/syscall/fchmodat.rs
+++ b/src/syscall/fchmodat.rs
@@ -1,7 +1,9 @@
 //! The `fchmodat` system call allows change the permissions on a file.
 
-use super::util;
+use super::util::at;
 use crate::errno::Errno;
+use crate::file::path::PathBuf;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use core::ffi::c_int;
@@ -15,26 +17,34 @@ pub fn fchmodat(
 	mode: i32,
 	flags: c_int,
 ) -> Result<i32, Errno> {
-	let (file_mutex, ap) = {
+	let (fds_mutex, path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let ap = proc.access_profile;
+		let rs = ResolutionSettings::for_process(&*proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
 
+		let fds_mutex = proc.file_descriptors.clone().unwrap();
+
 		let pathname = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let file_mutex = util::get_file_at(proc, dirfd, pathname, true, flags)?;
+		let path = PathBuf::try_from(pathname)?;
 
-		(file_mutex, ap)
+		(fds_mutex, path, rs)
+	};
+
+	let fds = fds_mutex.lock();
+
+	let Resolved::Found(file_mutex) = at::get_file(&fds, rs, dirfd, &path, flags)? else {
+		return Err(errno!(ENOENT));
 	};
 	let mut file = file_mutex.lock();
 
-	// Check permissions
-	if !ap.can_set_file_permissions(&file) {
+	// Check permission
+	if !rs.access_profile.can_set_file_permissions(&file) {
 		return Err(errno!(EPERM));
 	}
 

--- a/src/syscall/getcwd.rs
+++ b/src/syscall/getcwd.rs
@@ -17,7 +17,7 @@ pub fn getcwd(buf: SyscallSlice<u8>, size: usize) -> Result<i32, Errno> {
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
-	let cwd = crate::format!("{}", proc.cwd)?;
+	let cwd = crate::format!("{}", proc.cwd.0)?;
 
 	// Checking that the buffer is large enough
 	if size < cwd.len() + 1 {

--- a/src/syscall/link.rs
+++ b/src/syscall/link.rs
@@ -17,14 +17,12 @@ pub fn link(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Errno
 	let oldpath_str = oldpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-	let old_path = Path::new(oldpath_str)?;
-	let _old_path = super::util::get_absolute_path(&proc, old_path)?;
+	let _old_path = Path::new(oldpath_str)?;
 
 	let newpath_str = newpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-	let new_path = Path::new(newpath_str)?;
-	let _new_path = super::util::get_absolute_path(&proc, new_path)?;
+	let _new_path = Path::new(newpath_str)?;
 
 	// TODO Get file at `old_path`
 	// TODO Create the link to the file

--- a/src/syscall/link.rs
+++ b/src/syscall/link.rs
@@ -17,13 +17,13 @@ pub fn link(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Errno
 	let oldpath_str = oldpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-	let old_path = Path::from_str(oldpath_str, true)?;
+	let old_path = Path::new(oldpath_str)?;
 	let _old_path = super::util::get_absolute_path(&proc, old_path)?;
 
 	let newpath_str = newpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-	let new_path = Path::from_str(newpath_str, true)?;
+	let new_path = Path::new(newpath_str)?;
 	let _new_path = super::util::get_absolute_path(&proc, new_path)?;
 
 	// TODO Get file at `old_path`

--- a/src/syscall/linkat.rs
+++ b/src/syscall/linkat.rs
@@ -1,7 +1,10 @@
 //! This `linkat` syscall creates a new hard link to a file.
 
+use super::util::at;
 use crate::errno::Errno;
+use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -16,36 +19,51 @@ pub fn linkat(
 	newpath: SyscallString,
 	flags: c_int,
 ) -> Result<i32, Errno> {
-	let (old_mutex, new_parent_mutex, new_name, ap) = {
+	let (fds_mutex, oldpath, newpath, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let ap = proc.access_profile;
+		let rs = ResolutionSettings::for_process(&*proc, false);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
 
+		let fds_mutex = proc.file_descriptors.clone().unwrap();
+
 		let oldpath = oldpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let old = super::util::get_file_at(proc, olddirfd, oldpath, false, flags)?;
+		let oldpath = Path::new(oldpath)?;
 
 		let proc = proc_mutex.lock();
 		let newpath = newpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let (new_parent, new_name) =
-			super::util::get_parent_at_with_name(proc, newdirfd, newpath, false, flags)?;
+		let newpath = Path::new(newpath)?;
 
-		(old, new_parent, new_name, ap)
+		(fds_mutex, oldpath, newpath, rs)
 	};
 
+	let fds = fds_mutex.lock();
+
+	let Resolved::Found(old_mutex) = at::get_file(&fds, rs, olddirfd, oldpath, flags)? else {
+		return Err(errno!(ENOENT));
+	};
 	let mut old = old_mutex.lock();
 	if matches!(old.get_type(), FileType::Directory) {
 		return Err(errno!(EISDIR));
 	}
-	let new_parent = new_parent_mutex.lock();
 
-	vfs::create_link(&new_parent, &new_name, &mut old, &ap)?;
+	let Resolved::Creatable {
+		parent: new_parent,
+		name: new_name,
+	} = at::get_file(&fds, rs, newdirfd, newpath, 0)?
+	else {
+		return Err(errno!(EEXIST));
+	};
+	let new_parent = new_parent.lock();
+
+	vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
+
 	Ok(0)
 }

--- a/src/syscall/linkat.rs
+++ b/src/syscall/linkat.rs
@@ -46,6 +46,6 @@ pub fn linkat(
 	}
 	let new_parent = new_parent_mutex.lock();
 
-	vfs::create_link(&mut old, &new_parent, &new_name, &ap)?;
+	vfs::create_link(&new_parent, &new_name, &mut old, &ap)?;
 	Ok(0)
 }

--- a/src/syscall/linkat.rs
+++ b/src/syscall/linkat.rs
@@ -2,7 +2,7 @@
 
 use super::util::at;
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileType;
@@ -23,9 +23,9 @@ pub fn linkat(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let rs = ResolutionSettings::for_process(&*proc, false);
+		let rs = ResolutionSettings::for_process(&proc, false);
 
-		let mem_space = proc.get_mem_space().unwrap().clone();
+		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 
 		let fds_mutex = proc.file_descriptors.clone().unwrap();
@@ -33,20 +33,20 @@ pub fn linkat(
 		let oldpath = oldpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let oldpath = Path::new(oldpath)?;
+		let oldpath = PathBuf::try_from(oldpath)?;
 
-		let proc = proc_mutex.lock();
 		let newpath = newpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let newpath = Path::new(newpath)?;
+		let newpath = PathBuf::try_from(newpath)?;
 
 		(fds_mutex, oldpath, newpath, rs)
 	};
 
 	let fds = fds_mutex.lock();
 
-	let Resolved::Found(old_mutex) = at::get_file(&fds, rs, olddirfd, oldpath, flags)? else {
+	let Resolved::Found(old_mutex) = at::get_file(&fds, rs.clone(), olddirfd, &oldpath, flags)?
+	else {
 		return Err(errno!(ENOENT));
 	};
 	let mut old = old_mutex.lock();
@@ -57,13 +57,13 @@ pub fn linkat(
 	let Resolved::Creatable {
 		parent: new_parent,
 		name: new_name,
-	} = at::get_file(&fds, rs, newdirfd, newpath, 0)?
+	} = at::get_file(&fds, rs.clone(), newdirfd, &newpath, 0)?
 	else {
 		return Err(errno!(EEXIST));
 	};
 	let new_parent = new_parent.lock();
 
-	vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
+	vfs::create_link(&new_parent, new_name, &mut old, &rs.access_profile)?;
 
 	Ok(0)
 }

--- a/src/syscall/mkdir.rs
+++ b/src/syscall/mkdir.rs
@@ -25,7 +25,6 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 		// Path to the directory to create
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, mode, rs)

--- a/src/syscall/mkdir.rs
+++ b/src/syscall/mkdir.rs
@@ -3,6 +3,7 @@
 use crate::errno::Errno;
 use crate::file;
 use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
@@ -24,20 +25,17 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 
 		// Path to the directory to create
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, mode, rs)
 	};
 
-	// Get path of the parent directory and name of the directory to create
-	let mut parent_path = path.parent().unwrap_or(Path::root());
-	let name = parent_path.file_name();
-
 	// If the path is not empty, create
-	if let Some(name) = name {
+	if let Some(name) = path.file_name() {
 		// Get parent directory
-		let parent_mutex = vfs::get_file_from_path(&parent_path, &rs)?;
+		let parent_path = path.parent().unwrap_or(Path::root());
+		let parent_mutex = vfs::get_file_from_path(parent_path, &rs)?;
 		let mut parent = parent_mutex.lock();
 
 		// Create the directory

--- a/src/syscall/mkdir.rs
+++ b/src/syscall/mkdir.rs
@@ -23,15 +23,15 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 
 		// Path to the directory to create
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		let path = Path::from_str(path, true)?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, mode, proc.access_profile)
 	};
 
 	// Get path of the parent directory and name of the directory to create
-	let mut parent_path = path;
-	let name = parent_path.pop();
+	let mut parent_path = path.parent().unwrap_or(Path::root());
+	let name = parent_path.file_name();
 
 	// If the path is not empty, create
 	if let Some(name) = name {
@@ -42,7 +42,7 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 		// Create the directory
 		vfs::create_file(
 			&mut parent,
-			name,
+			name.try_into()?,
 			&ap,
 			mode,
 			FileContent::Directory(HashMap::new()),

--- a/src/syscall/mkdir.rs
+++ b/src/syscall/mkdir.rs
@@ -4,6 +4,7 @@ use crate::errno::Errno;
 use crate::file;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -12,7 +13,7 @@ use macros::syscall;
 
 #[syscall]
 pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
-	let (path, mode, ap) = {
+	let (path, mode, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -26,7 +27,8 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
-		(path, mode, proc.access_profile)
+		let rs = ResolutionSettings::for_process(&proc, true);
+		(path, mode, rs)
 	};
 
 	// Get path of the parent directory and name of the directory to create
@@ -36,14 +38,14 @@ pub fn mkdir(pathname: SyscallString, mode: file::Mode) -> Result<i32, Errno> {
 	// If the path is not empty, create
 	if let Some(name) = name {
 		// Get parent directory
-		let parent_mutex = vfs::get_file_from_path(&parent_path, &ap, true)?;
+		let parent_mutex = vfs::get_file_from_path(&parent_path, &rs)?;
 		let mut parent = parent_mutex.lock();
 
 		// Create the directory
 		vfs::create_file(
 			&mut parent,
 			name.try_into()?,
-			&ap,
+			&rs.access_profile,
 			mode,
 			FileContent::Directory(HashMap::new()),
 		)?;

--- a/src/syscall/mknod.rs
+++ b/src/syscall/mknod.rs
@@ -22,7 +22,8 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 
-		let path = Path::from_str(pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?, true)?;
+		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let umask = proc.umask;
@@ -31,9 +32,9 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 	};
 
 	// Path of the parent directory
-	let mut parent_path = path;
+	let parent_path = path.parent().unwrap_or(Path::root());
 	// File name
-	let Some(name) = parent_path.pop() else {
+	let Some(name) = path.file_name() else {
 		return Err(errno!(EEXIST));
 	};
 
@@ -63,7 +64,7 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 	// Create the node
 	let parent_mutex = vfs::get_file_from_path(&parent_path, &ap, true)?;
 	let mut parent = parent_mutex.lock();
-	vfs::create_file(&mut parent, name, &ap, mode, file_content)?;
+	vfs::create_file(&mut parent, name.try_into()?, &ap, mode, file_content)?;
 
 	Ok(0)
 }

--- a/src/syscall/mknod.rs
+++ b/src/syscall/mknod.rs
@@ -5,6 +5,7 @@ use crate::errno;
 use crate::errno::Errno;
 use crate::file;
 use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
@@ -24,7 +25,7 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 		let mem_space_guard = mem_space.lock();
 
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let umask = proc.umask;
 
@@ -63,7 +64,7 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 	};
 
 	// Create the node
-	let parent_mutex = vfs::get_file_from_path(&parent_path, &rs)?;
+	let parent_mutex = vfs::get_file_from_path(parent_path, &rs)?;
 	let mut parent = parent_mutex.lock();
 	vfs::create_file(
 		&mut parent,

--- a/src/syscall/mknod.rs
+++ b/src/syscall/mknod.rs
@@ -25,7 +25,6 @@ pub fn mknod(pathname: SyscallString, mode: file::Mode, dev: u64) -> Result<i32,
 
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let umask = proc.umask;
 

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -1,5 +1,5 @@
 //! This module handles system calls. A system call is "function" that allows to
-//! communcate between userspace and kernelspace.
+//! communicate between userspace and kernelspace.
 //!
 //! Documentation for each system call can be retrieved from the man. Type the
 //! command: `man 2 <syscall>`

--- a/src/syscall/mount.rs
+++ b/src/syscall/mount.rs
@@ -7,6 +7,7 @@ use crate::file::mountpoint;
 use crate::file::mountpoint::MountSource;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallPtr;
 use crate::process::mem_space::ptr::SyscallString;
@@ -23,9 +24,16 @@ pub fn mount(
 	mountflags: c_ulong,
 	_data: SyscallPtr<c_void>,
 ) -> Result<i32, Errno> {
-	let (mount_source, target_path, fs_type) = {
+	let (mount_source, target_path, target_file, fs_type) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
+
+		// Check permission
+		if !proc.access_profile.is_privileged() {
+			return Err(errno!(EPERM));
+		}
+
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
@@ -40,27 +48,33 @@ pub fn mount(
 		// Get the mount source
 		let mount_source = MountSource::from_str(source_slice)?;
 
-		// Get the target file
+		// Get the target directory
 		let target_path = Path::new(target_slice)?;
 		let target_path = super::util::get_absolute_path(&proc, target_path)?;
-		let target_mutex = vfs::get_file_from_path(&target_path, &proc.access_profile, true)?;
-		let target_file = target_mutex.lock();
+		let target_file_mutex = vfs::get_file_from_path(&target_path, &rs)?;
+		let target_file = target_file_mutex.lock();
 
 		// Check the target is a directory
 		if target_file.get_type() != FileType::Directory {
 			return Err(errno!(ENOTDIR));
 		}
 
-		// TODO Check for loop between source and target
-
 		let fs_type = fs::get_type(filesystemtype_slice).ok_or(errno!(ENODEV))?;
 
-		(mount_source, target_path, fs_type)
+		(mount_source, target_path, target_file_mutex, fs_type)
 	};
+
+	let target_location = target_file.lock().get_location().clone();
 
 	// TODO Use `data`
 	// Create mountpoint
-	mountpoint::create(mount_source, Some(fs_type), mountflags, target_path)?;
+	mountpoint::create(
+		mount_source,
+		Some(fs_type),
+		mountflags,
+		target_path,
+		target_location,
+	)?;
 
 	Ok(0)
 }

--- a/src/syscall/mount.rs
+++ b/src/syscall/mount.rs
@@ -5,7 +5,7 @@ use crate::errno::Errno;
 use crate::file::fs;
 use crate::file::mountpoint;
 use crate::file::mountpoint::MountSource;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
@@ -24,7 +24,7 @@ pub fn mount(
 	mountflags: c_ulong,
 	_data: SyscallPtr<c_void>,
 ) -> Result<i32, Errno> {
-	let (mount_source, target_path, target_file, fs_type) = {
+	let (mount_source, target_path, fs_type, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -49,21 +49,20 @@ pub fn mount(
 		let mount_source = MountSource::from_str(source_slice)?;
 
 		// Get the target directory
-		let target_path = Path::new(target_slice)?;
-		let target_file_mutex = vfs::get_file_from_path(&target_path, &rs)?;
-		let target_file = target_file_mutex.lock();
-
-		// Check the target is a directory
-		if target_file.get_type() != FileType::Directory {
-			return Err(errno!(ENOTDIR));
-		}
+		let target_path = PathBuf::try_from(target_slice)?;
 
 		let fs_type = fs::get_type(filesystemtype_slice).ok_or(errno!(ENODEV))?;
 
-		(mount_source, target_path, target_file_mutex, fs_type)
+		(mount_source, target_path, fs_type, rs)
 	};
 
-	let target_location = target_file.lock().get_location().clone();
+	let target_file_mutex = vfs::get_file_from_path(&target_path, &rs)?;
+	let target_file = target_file_mutex.lock();
+	// Check the target is a directory
+	if target_file.get_type() != FileType::Directory {
+		return Err(errno!(ENOTDIR));
+	}
+	let target_location = target_file.get_location().clone();
 
 	// TODO Use `data`
 	// Create mountpoint

--- a/src/syscall/mount.rs
+++ b/src/syscall/mount.rs
@@ -50,7 +50,6 @@ pub fn mount(
 
 		// Get the target directory
 		let target_path = Path::new(target_slice)?;
-		let target_path = super::util::get_absolute_path(&proc, target_path)?;
 		let target_file_mutex = vfs::get_file_from_path(&target_path, &rs)?;
 		let target_file = target_file_mutex.lock();
 

--- a/src/syscall/mount.rs
+++ b/src/syscall/mount.rs
@@ -46,7 +46,7 @@ pub fn mount(
 			.ok_or(errno!(EFAULT))?;
 
 		// Get the mount source
-		let mount_source = MountSource::from_str(source_slice)?;
+		let mount_source = MountSource::new(source_slice)?;
 
 		// Get the target directory
 		let target_path = PathBuf::try_from(target_slice)?;

--- a/src/syscall/mount.rs
+++ b/src/syscall/mount.rs
@@ -11,7 +11,6 @@ use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallPtr;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
-use crate::util::TryClone;
 use core::ffi::c_ulong;
 use core::ffi::c_void;
 use macros::syscall;
@@ -24,14 +23,12 @@ pub fn mount(
 	mountflags: c_ulong,
 	_data: SyscallPtr<c_void>,
 ) -> Result<i32, Errno> {
-	let (mount_source, fs_type, target_path) = {
+	let (mount_source, target_path, fs_type) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
-
-		let cwd = proc.chroot.try_clone()?.concat(&proc.cwd)?;
 
 		// Get strings
 		let source_slice = source.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
@@ -41,10 +38,10 @@ pub fn mount(
 			.ok_or(errno!(EFAULT))?;
 
 		// Get the mount source
-		let mount_source = MountSource::from_str(source_slice, cwd)?;
+		let mount_source = MountSource::from_str(source_slice)?;
 
 		// Get the target file
-		let target_path = Path::from_str(target_slice, true)?;
+		let target_path = Path::new(target_slice)?;
 		let target_path = super::util::get_absolute_path(&proc, target_path)?;
 		let target_mutex = vfs::get_file_from_path(&target_path, &proc.access_profile, true)?;
 		let target_file = target_mutex.lock();
@@ -58,7 +55,7 @@ pub fn mount(
 
 		let fs_type = fs::get_type(filesystemtype_slice).ok_or(errno!(ENODEV))?;
 
-		(mount_source, fs_type, target_path)
+		(mount_source, target_path, fs_type)
 	};
 
 	// TODO Use `data`

--- a/src/syscall/open.rs
+++ b/src/syscall/open.rs
@@ -8,7 +8,7 @@ use crate::file;
 use crate::file::fd::FD_CLOEXEC;
 use crate::file::open_file;
 use crate::file::open_file::OpenFile;
-use crate::file::path::Path;
+use crate::file::path::{Path, PathBuf};
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
 use crate::file::vfs::{ResolutionSettings, Resolved};
@@ -111,8 +111,7 @@ pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
-		let abs_path = super::util::get_absolute_path(&proc, path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let follow_links = flags & open_file::O_NOFOLLOW == 0;
 		let create = flags & open_file::O_CREAT != 0;
@@ -123,7 +122,7 @@ pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i
 
 		let fds_mutex = proc.file_descriptors.clone().unwrap();
 
-		(abs_path, rs, mode, fds_mutex)
+		(path, rs, mode, fds_mutex)
 	};
 
 	// Get file

--- a/src/syscall/open.rs
+++ b/src/syscall/open.rs
@@ -19,7 +19,6 @@ use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
-use crate::util::TryClone;
 use core::ffi::c_int;
 use macros::syscall;
 
@@ -45,7 +44,7 @@ pub const STATUS_FLAGS_MASK: i32 = !(open_file::O_CLOEXEC
 ///
 /// The access profile is also used to check permissions.
 fn get_file(
-	path: Path,
+	path: &Path,
 	flags: i32,
 	mode: Mode,
 	access_profile: &AccessProfile,
@@ -55,16 +54,16 @@ fn get_file(
 
 	if flags & open_file::O_CREAT != 0 {
 		// Get the path of the parent directory
-		let mut parent_path = path;
+		let parent_path = path.parent().unwrap_or(Path::root());
 		// The file's basename
-		let name = parent_path.pop().ok_or_else(|| errno!(ENOENT))?;
+		let name = path.file_name().ok_or_else(|| errno!(ENOENT))?;
 
 		// The parent directory
 		let parent_mutex = vfs::get_file_from_path(&parent_path, access_profile, true)?;
 		let mut parent = parent_mutex.lock();
 
 		let file_result =
-			vfs::get_file_from_parent(&parent, name.try_clone()?, access_profile, follow_links);
+			vfs::get_file_from_parent(&parent, name.try_into()?, access_profile, follow_links);
 		let file = match file_result {
 			// If the file is found, return it
 			Ok(file) => file,
@@ -72,7 +71,7 @@ fn get_file(
 			// Else, create it
 			Err(e) if e.as_int() == errno::ENOENT => vfs::create_file(
 				&mut parent,
-				name,
+				name.try_into()?,
 				access_profile,
 				mode,
 				FileContent::Regular,
@@ -135,7 +134,8 @@ pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i
 
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
-		let path = Path::from_str(pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?, true)?;
+		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
+		let path = Path::new(path)?;
 		let abs_path = super::util::get_absolute_path(&proc, path)?;
 
 		let mode = mode & !proc.umask;
@@ -145,7 +145,7 @@ pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i
 	};
 
 	// Get file
-	let file_mutex = get_file(path, flags, mode, &ap)?;
+	let file_mutex = get_file(&path, flags, mode, &ap)?;
 	let mut file = file_mutex.lock();
 
 	// Handle flags

--- a/src/syscall/open.rs
+++ b/src/syscall/open.rs
@@ -11,6 +11,7 @@ use crate::file::open_file::OpenFile;
 use crate::file::path::Path;
 use crate::file::perm::AccessProfile;
 use crate::file::vfs;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::File;
 use crate::file::FileContent;
 use crate::file::FileType;
@@ -33,64 +34,39 @@ pub const STATUS_FLAGS_MASK: i32 = !(open_file::O_CLOEXEC
 
 // TODO Implement all flags
 
-/// Returns the file at the given path `path`.
+/// Resolves the given `path` and returns the file.
 ///
-/// If the file doesn't exist and the `O_CREAT` flag is set, the file is created,
-/// then the function returns it.
-/// If the flag is not set, the function returns an error with the appropriate errno.
+/// If enabled, the file is create.
 ///
-/// If the file is to be created, the function uses `mode` to set its permissions and the provided
+/// If the file is created, the function uses `mode` to set its permissions and the provided
 /// access profile to set the user ID and group ID.
-///
-/// The access profile is also used to check permissions.
-fn get_file(
-	path: &Path,
-	flags: i32,
-	mode: Mode,
-	access_profile: &AccessProfile,
-) -> EResult<Arc<Mutex<File>>> {
-	// Tells whether to follow symbolic links on the last component of the path.
-	let follow_links = flags & open_file::O_NOFOLLOW == 0;
-
-	if flags & open_file::O_CREAT != 0 {
-		// Get the path of the parent directory
-		let parent_path = path.parent().unwrap_or(Path::root());
-		// The file's basename
-		let name = path.file_name().ok_or_else(|| errno!(ENOENT))?;
-
-		// The parent directory
-		let parent_mutex = vfs::get_file_from_path(&parent_path, access_profile, true)?;
-		let mut parent = parent_mutex.lock();
-
-		let file_result =
-			vfs::get_file_from_parent(&parent, name.try_into()?, access_profile, follow_links);
-		let file = match file_result {
-			// If the file is found, return it
-			Ok(file) => file,
-
-			// Else, create it
-			Err(e) if e.as_int() == errno::ENOENT => vfs::create_file(
+fn get_file(path: &Path, rs: &ResolutionSettings, mode: Mode) -> EResult<Arc<Mutex<File>>> {
+	let resolved = vfs::resolve_path(path, rs)?;
+	let file = match resolved {
+		Resolved::Found(file) => file,
+		Resolved::Creatable {
+			parent,
+			name,
+		} => {
+			let mut parent = parent.lock();
+			let name = name.try_into()?;
+			vfs::create_file(
 				&mut parent,
-				name.try_into()?,
-				access_profile,
+				name,
+				&rs.access_profile,
 				mode,
 				FileContent::Regular,
-			)?,
-
-			e => return e,
-		};
-		// Get file type. There cannot be a race condition since the type of a file cannot be
-		// changed
-		let file_type = file.lock().get_type();
-		match file_type {
-			// Cannot open symbolic links themselves
-			FileType::Link => Err(errno!(ELOOP)),
-			_ => Ok(file),
+			)?
 		}
-	} else {
-		// The file is the root directory
-		vfs::get_file_from_path(&path, access_profile, follow_links)
+	};
+	// Get file type. There cannot be a race condition since the type of a file cannot be
+	// changed
+	let file_type = file.lock().get_type();
+	// Cannot open symbolic links themselves
+	if file_type == FileType::Link {
+		return Err(errno!(ELOOP));
 	}
+	Ok(file)
 }
 
 /// The function checks the system call's flags and performs the action associated with some of
@@ -129,7 +105,7 @@ pub fn handle_flags(file: &mut File, flags: i32, access_profile: &AccessProfile)
 /// Performs the open system call.
 pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i32> {
 	let proc_mutex = Process::current_assert();
-	let (path, mode, ap, fds_mutex) = {
+	let (path, rs, mode, fds_mutex) = {
 		let proc = proc_mutex.lock();
 
 		let mem_space = proc.get_mem_space().unwrap();
@@ -138,19 +114,24 @@ pub fn open_(pathname: SyscallString, flags: i32, mode: file::Mode) -> EResult<i
 		let path = Path::new(path)?;
 		let abs_path = super::util::get_absolute_path(&proc, path)?;
 
+		let follow_links = flags & open_file::O_NOFOLLOW == 0;
+		let create = flags & open_file::O_CREAT != 0;
+		let mut rs = ResolutionSettings::for_process(&proc, follow_links);
+		rs.create = create;
+
 		let mode = mode & !proc.umask;
 
 		let fds_mutex = proc.file_descriptors.clone().unwrap();
-		(abs_path, mode, proc.access_profile, fds_mutex)
+
+		(abs_path, rs, mode, fds_mutex)
 	};
 
 	// Get file
-	let file_mutex = get_file(&path, flags, mode, &ap)?;
-	let mut file = file_mutex.lock();
-
-	// Handle flags
-	handle_flags(&mut file, flags, &ap)?;
-	drop(file);
+	let file_mutex = get_file(&path, &rs, mode)?;
+	{
+		let mut file = file_mutex.lock();
+		handle_flags(&mut file, flags, &rs.access_profile)?;
+	}
 
 	// Create open file description
 	let open_file = OpenFile::new(file_mutex.clone(), flags)?;

--- a/src/syscall/openat.rs
+++ b/src/syscall/openat.rs
@@ -1,23 +1,26 @@
 //! The `openat` syscall allows to open a file.
 
-use super::util;
-use crate::errno::Errno;
-use crate::file::fd::FD_CLOEXEC;
-use crate::file::open_file;
+use crate::errno::{EResult, Errno};
+use crate::file::fd::{FileDescriptorTable, FD_CLOEXEC};
 use crate::file::open_file::OpenFile;
+use crate::file::path::Path;
+use crate::file::path::PathBuf;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::File;
 use crate::file::FileContent;
 use crate::file::Mode;
+use crate::file::{open_file, vfs};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
+use crate::syscall::util::at;
 use crate::util::lock::Mutex;
 use crate::util::ptr::arc::Arc;
 use core::ffi::c_int;
 use macros::syscall;
 
 // TODO Implement all flags
-// TODO clean up: multiple locks to process
 
+// TODO rewrite doc
 /// Returns the file at the given path.
 ///
 /// Arguments:
@@ -33,36 +36,32 @@ use macros::syscall;
 ///
 /// If the file is to be created, the function uses `mode` to set its permissions.
 fn get_file(
-	dirfd: i32,
-	pathname: SyscallString,
-	flags: i32,
+	fds: &FileDescriptorTable,
+	dirfd: c_int,
+	path: &Path,
+	flags: c_int,
+	rs: ResolutionSettings,
 	mode: Mode,
-) -> Result<Arc<Mutex<File>>, Errno> {
-	// Tells whether to follow symbolic links on the last component of the path.
-	let follow_links = flags & open_file::O_NOFOLLOW == 0;
-
-	let proc_mutex = Process::current_assert();
-	let proc = proc_mutex.lock();
-
-	let mem_space = proc.get_mem_space().unwrap().clone();
-	let mem_space_guard = mem_space.lock();
-
-	let pathname = pathname
-		.get(&mem_space_guard)?
-		.ok_or_else(|| errno!(EFAULT))?;
-
-	if flags & open_file::O_CREAT != 0 {
-		util::create_file_at(
-			proc,
-			dirfd,
-			pathname,
-			mode,
-			FileContent::Regular,
-			follow_links,
-			0,
-		)
-	} else {
-		util::get_file_at(proc, dirfd, pathname, follow_links, 0)
+) -> EResult<Arc<Mutex<File>>> {
+	let create = flags & open_file::O_CREAT != 0;
+	let resolved = at::get_file(fds, rs, dirfd, path, flags)?;
+	match resolved {
+		Resolved::Found(file) => Ok(file),
+		Resolved::Creatable {
+			parent,
+			name,
+		} if create => {
+			let parent = parent.lock();
+			let name = name.try_into()?;
+			vfs::create_file(
+				&mut *parent,
+				name,
+				&rs.access_profile,
+				mode,
+				FileContent::Regular,
+			)
+		}
+		_ => Err(errno!(ENOENT)),
 	}
 }
 
@@ -73,27 +72,46 @@ pub fn openat(
 	flags: c_int,
 	mode: Mode,
 ) -> Result<i32, Errno> {
-	let proc_mutex = Process::current_assert();
-	let ap = proc_mutex.lock().access_profile;
+	let (rs, path, fds_mutex) = {
+		let proc_mutex = Process::current_assert();
+		let proc = proc_mutex.lock();
 
-	// Get the file
-	let file_mutex = get_file(dirfd, pathname, flags, mode)?;
-	let mut file = file_mutex.lock();
+		let follow_link = flags & open_file::O_NOFOLLOW == 0;
+		let rs = ResolutionSettings::for_process(&*proc, follow_link);
 
-	// Handle flags
-	super::open::handle_flags(&mut file, flags, &ap)?;
-	drop(file);
+		let mem_space = proc.get_mem_space().unwrap().clone();
+		let mem_space_guard = mem_space.lock();
+
+		let pathname = pathname
+			.get(&mem_space_guard)?
+			.ok_or_else(|| errno!(EFAULT))?;
+		let path = PathBuf::try_from(pathname)?;
+
+		let fds_mutex = proc.file_descriptors.clone().unwrap();
+
+		(rs, path, fds_mutex)
+	};
+
+	let mut fds = fds_mutex.lock();
+
+	// Get file
+	let file_mutex = get_file(&fds, dirfd, &path, flags, rs, mode)?;
+	{
+		let mut file = file_mutex.lock();
+		super::open::handle_flags(&mut file, flags, &rs.access_profile)?;
+	}
 
 	let open_file = OpenFile::new(file_mutex, flags)?;
 
+	// Create FD
 	let mut fd_flags = 0;
 	if flags & open_file::O_CLOEXEC != 0 {
 		fd_flags |= FD_CLOEXEC;
 	}
-	let proc = proc_mutex.lock();
-	let fds_mutex = proc.file_descriptors.as_ref().unwrap();
-	let mut fds = fds_mutex.lock();
 	let fd = fds.create_fd(fd_flags, open_file)?;
+	let fd_id = fd.get_id();
 
-	Ok(fd.get_id() as _)
+	// TODO flush file? (see `open` syscall)
+
+	Ok(fd_id as _)
 }

--- a/src/syscall/pipe.rs
+++ b/src/syscall/pipe.rs
@@ -26,7 +26,7 @@ pub fn pipe(pipefd: SyscallPtr<[c_int; 2]>) -> Result<i32, Errno> {
 	};
 
 	let loc = buffer::register(None, Arc::new(Mutex::new(PipeBuffer::try_default()?))?)?;
-	let file = vfs::get_file_by_location(&loc)?;
+	let file = vfs::get_file_from_location(&loc)?;
 
 	let open_file0 = OpenFile::new(file.clone(), open_file::O_RDONLY)?;
 	let open_file1 = OpenFile::new(file, open_file::O_WRONLY)?;

--- a/src/syscall/pipe2.rs
+++ b/src/syscall/pipe2.rs
@@ -32,7 +32,7 @@ pub fn pipe2(pipefd: SyscallPtr<[c_int; 2]>, flags: c_int) -> Result<i32, Errno>
 	};
 
 	let loc = buffer::register(None, Arc::new(Mutex::new(PipeBuffer::try_default()?))?)?;
-	let file = vfs::get_file_by_location(&loc)?;
+	let file = vfs::get_file_from_location(&loc)?;
 
 	let open_file0 = OpenFile::new(file.clone(), open_file::O_RDONLY)?;
 	let open_file1 = OpenFile::new(file, open_file::O_WRONLY)?;

--- a/src/syscall/readlink.rs
+++ b/src/syscall/readlink.rs
@@ -3,6 +3,7 @@
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
 use crate::process::mem_space::ptr::SyscallSlice;
 use crate::process::mem_space::ptr::SyscallString;
@@ -18,7 +19,7 @@ pub fn readlink(
 	bufsiz: usize,
 ) -> Result<i32, Errno> {
 	// process lock has to be dropped to avoid deadlock with procfs
-	let (mem_space_mutex, path, ap) = {
+	let (mem_space_mutex, path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -31,11 +32,13 @@ pub fn readlink(
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		drop(mem_space);
-		(mem_space_mutex, path, proc.access_profile)
+
+		let rs = ResolutionSettings::for_process(&proc, false);
+		(mem_space_mutex, path, rs)
 	};
 
 	// Get link's target
-	let file_mutex = vfs::get_file_from_path(&path, &ap, false)?;
+	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
 	let file = file_mutex.lock();
 	let FileContent::Link(target) = file.get_content() else {
 		return Err(errno!(EINVAL));

--- a/src/syscall/readlink.rs
+++ b/src/syscall/readlink.rs
@@ -27,7 +27,7 @@ pub fn readlink(
 
 		// Get file's path
 		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
-		let path = Path::from_str(path, true)?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		drop(mem_space);

--- a/src/syscall/readlink.rs
+++ b/src/syscall/readlink.rs
@@ -1,7 +1,7 @@
 //! The `readlink` syscall allows to read the target of a symbolic link.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
@@ -28,7 +28,7 @@ pub fn readlink(
 
 		// Get file's path
 		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		drop(mem_space);
 

--- a/src/syscall/readlink.rs
+++ b/src/syscall/readlink.rs
@@ -29,7 +29,6 @@ pub fn readlink(
 		// Get file's path
 		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		drop(mem_space);
 

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -40,10 +40,13 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 	let old_mutex = vfs::get_file_from_path(&old_path, &rs)?;
 	let mut old = old_mutex.lock();
 
-	let new_parent_mutex = vfs::get_file_from_path(&new_parent_path, &ResolutionSettings {
-		follow_links: true,
-		..rs
-	})?;
+	let new_parent_mutex = vfs::get_file_from_path(
+		&new_parent_path,
+		&ResolutionSettings {
+			follow_links: true,
+			..rs
+		},
+	)?;
 	let mut new_parent = new_parent_mutex.lock();
 
 	// TODO Check permissions if sticky bit is set

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -40,8 +40,10 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 	let old_mutex = vfs::get_file_from_path(&old_path, &rs)?;
 	let mut old = old_mutex.lock();
 
-	rs.follow_links = true;
-	let new_parent_mutex = vfs::get_file_from_path(&new_parent_path, &rs)?;
+	let new_parent_mutex = vfs::get_file_from_path(&new_parent_path, &ResolutionSettings {
+		follow_links: true,
+		..rs
+	})?;
 	let mut new_parent = new_parent_mutex.lock();
 
 	// TODO Check permissions if sticky bit is set
@@ -64,8 +66,8 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 
 		// TODO On fail, undo
 
-		file::util::copy_file(&mut old, &mut new_parent, String::try_from(new_name)?)?;
-		file::util::remove_recursive(&mut old, &rs.access_profile)?;
+		file::util::copy_file(&mut old, &mut new_parent, String::try_from(new_name)?, &rs)?;
+		file::util::remove_recursive(&mut old, &rs)?;
 	}
 
 	Ok(0)

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -43,7 +43,7 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 	let new_parent_mutex = vfs::get_file_from_path(
 		&new_parent_path,
 		&ResolutionSettings {
-			follow_links: true,
+			follow_link: true,
 			..rs
 		},
 	)?;

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -1,21 +1,21 @@
 //! The `rename` system call renames a file.
 
 use crate::errno::Errno;
-use crate::file;
 use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
-use crate::util::container::string::String;
 use macros::syscall;
 
 // TODO implementation probably can be merged with `renameat2`
+// TODO do not allow rename if the file is in use (example: cwd of a process, listing subfiles,
+// etc...)
 
 #[syscall]
 pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Errno> {
-	let (old_path, mut new_path, mut rs) = {
+	let (old_path, new_path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -36,6 +36,12 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 		(old_path, new_path, rs)
 	};
 
+	let old_parent_path = old_path.parent().ok_or_else(|| errno!(ENOTDIR))?;
+	let old_name = old_path.file_name().ok_or_else(|| errno!(ENOENT))?;
+
+	let old_parent_mutex = vfs::get_file_from_path(old_parent_path, &rs)?;
+	let mut old_parent = old_parent_mutex.lock();
+
 	let old_mutex = vfs::get_file_from_path(&old_path, &rs)?;
 	let mut old = old_mutex.lock();
 	// Cannot rename mountpoint
@@ -43,39 +49,29 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 		return Err(errno!(EBUSY));
 	}
 
-	let new_parent_path = new_path.parent().ok_or_else(|| errno!(ENOENT))?;
+	let new_parent_path = new_path.parent().ok_or_else(|| errno!(ENOTDIR))?;
 	let new_parent_mutex = vfs::get_file_from_path(
-		&new_parent_path,
+		new_parent_path,
 		&ResolutionSettings {
 			follow_link: true,
 			..rs
 		},
 	)?;
-	let mut new_parent = new_parent_mutex.lock();
+	let new_parent = new_parent_mutex.lock();
 	let new_name = new_path.file_name().ok_or_else(|| errno!(ENOENT))?;
+
+	// If source and destination are on different mountpoints, error
+	if new_parent.get_location().get_mountpoint_id() != old.get_location().get_mountpoint_id() {
+		return Err(errno!(EXDEV));
+	}
 
 	// TODO Check permissions if sticky bit is set
 
-	if new_parent.get_location() == old.get_location() {
-		// Old and new are both on the same filesystem
+	vfs::create_link(&new_parent, new_name, &mut old, &rs.access_profile)?;
 
+	if old.get_type() != FileType::Directory {
 		// TODO On fail, undo
-
-		// Create link at new location
-		// The `..` entry is already updated by the file system since having the same
-		// directory in several locations is not allowed
-		vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
-
-		if old.get_type() != FileType::Directory {
-			vfs::remove_file(&mut old, &rs.access_profile)?;
-		}
-	} else {
-		// Old and new are on different filesystems.
-
-		// TODO On fail, undo
-
-		file::util::copy_file(&mut old, &mut new_parent, String::try_from(new_name)?, &rs)?;
-		file::util::remove_recursive(&mut old, &rs)?;
+		vfs::remove_file(&mut old_parent, old_name, &rs.access_profile)?;
 	}
 
 	Ok(0)

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -59,7 +59,7 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 		// Create link at new location
 		// The `..` entry is already updated by the file system since having the same
 		// directory in several locations is not allowed
-		vfs::create_link(&mut old, &new_parent, &new_name, &rs.access_profile)?;
+		vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
 
 		if old.get_type() != FileType::Directory {
 			vfs::remove_file(&mut old, &rs.access_profile)?;

--- a/src/syscall/rename.rs
+++ b/src/syscall/rename.rs
@@ -2,11 +2,12 @@
 
 use crate::errno::Errno;
 use crate::file;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
+use crate::util::container::string::String;
 use macros::syscall;
 
 // TODO implementation probably can be merged with `renameat2`
@@ -23,16 +24,16 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 		let oldpath = oldpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let old_path = Path::from_str(oldpath, true)?;
+		let old_path = PathBuf::try_from(oldpath)?;
 
 		let newpath = newpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let new_parent_path = Path::from_str(newpath, true)?;
+		let new_parent_path = PathBuf::try_from(newpath)?;
 
 		(old_path, new_parent_path, proc.access_profile)
 	};
-	let new_name = new_parent_path.pop().ok_or_else(|| errno!(ENOENT))?;
+	let new_name = new_parent_path.file_name().ok_or_else(|| errno!(ENOENT))?;
 
 	let old_mutex = vfs::get_file_from_path(&old_path, &ap, false)?;
 	let mut old = old_mutex.lock();
@@ -42,7 +43,7 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 
 	// TODO Check permissions if sticky bit is set
 
-	if new_parent.get_location().get_mountpoint_id() == old.get_location().get_mountpoint_id() {
+	if new_parent.get_location() == old.get_location() {
 		// Old and new are both on the same filesystem
 
 		// TODO On fail, undo
@@ -60,7 +61,7 @@ pub fn rename(oldpath: SyscallString, newpath: SyscallString) -> Result<i32, Err
 
 		// TODO On fail, undo
 
-		file::util::copy_file(&mut old, &mut new_parent, new_name)?;
+		file::util::copy_file(&mut old, &mut new_parent, String::try_from(new_name)?)?;
 		file::util::remove_recursive(&mut old, &ap)?;
 	}
 

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -61,7 +61,7 @@ pub fn renameat2(
 		// Create link at new location
 		// The `..` entry is already updated by the file system since having the same
 		// directory in several locations is not allowed
-		vfs::create_link(&mut old, &new_parent, &new_name, &rs.access_profile)?;
+		vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
 
 		if old.get_type() != FileType::Directory {
 			vfs::remove_file(&mut old, &rs.access_profile)?;

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -2,7 +2,6 @@
 
 use super::util::at;
 use crate::errno::Errno;
-use crate::file;
 use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::{ResolutionSettings, Resolved};
@@ -18,6 +17,8 @@ const RENAME_NOREPLACE: c_int = 1;
 const RENAME_EXCHANGE: c_int = 2;
 
 // TODO implement flags
+// TODO do not allow rename if the file is in use (example: cwd of a process, listing subfiles,
+// etc...)
 
 #[syscall]
 pub fn renameat2(
@@ -31,7 +32,7 @@ pub fn renameat2(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let rs = ResolutionSettings::for_process(&*proc, false);
+		let rs = ResolutionSettings::for_process(&proc, false);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
@@ -53,7 +54,13 @@ pub fn renameat2(
 
 	let fds = fds_mutex.lock();
 
-	let Resolved::Found(old_mutex) = at::get_file(&fds, rs, olddirfd, &oldpath, 0)? else {
+	let old_parent_path = oldpath.parent().ok_or_else(|| errno!(ENOTDIR))?;
+	let old_name = oldpath.file_name().ok_or_else(|| errno!(ENOENT))?;
+
+	let old_parent_mutex = vfs::get_file_from_path(old_parent_path, &rs)?;
+	let mut old_parent = old_parent_mutex.lock();
+
+	let Resolved::Found(old_mutex) = at::get_file(&fds, rs.clone(), olddirfd, &oldpath, 0)? else {
 		return Err(errno!(ENOENT));
 	};
 	let mut old = old_mutex.lock();
@@ -66,34 +73,28 @@ pub fn renameat2(
 	let Resolved::Creatable {
 		parent: new_parent,
 		name: new_name,
-	} = at::get_file(&fds, rs, newdirfd, &newpath, 0)?
+	} = at::get_file(&fds, rs.clone(), newdirfd, &newpath, 0)?
 	else {
 		return Err(errno!(EEXIST));
 	};
-	let mut new_parent = new_parent.lock();
+	let new_parent = new_parent.lock();
+
+	// If source and destination are on different mountpoints, error
+	if new_parent.get_location().get_mountpoint_id() != old.get_location().get_mountpoint_id() {
+		return Err(errno!(EXDEV));
+	}
 
 	// TODO Check permissions if sticky bit is set
 
-	if new_parent.get_location().get_mountpoint_id() == old.get_location().get_mountpoint_id() {
-		// Old and new are both on the same filesystem
+	// TODO On fail, undo
 
-		// TODO On fail, undo
+	// Create link at new location
+	// The `..` entry is already updated by the file system since having the same
+	// directory in several locations is not allowed
+	vfs::create_link(&new_parent, new_name, &mut old, &rs.access_profile)?;
 
-		// Create link at new location
-		// The `..` entry is already updated by the file system since having the same
-		// directory in several locations is not allowed
-		vfs::create_link(&new_parent, &new_name, &mut old, &rs.access_profile)?;
-
-		if old.get_type() != FileType::Directory {
-			vfs::remove_file(&mut old, &rs.access_profile)?;
-		}
-	} else {
-		// Old and new are on different filesystems.
-
-		// TODO On fail, undo
-
-		file::util::copy_file(&mut old, &mut new_parent, new_name, &rs)?;
-		file::util::remove_recursive(&mut old, &rs)?;
+	if old.get_type() != FileType::Directory {
+		vfs::remove_file(&mut old_parent, old_name, &rs.access_profile)?;
 	}
 
 	Ok(0)

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -1,9 +1,11 @@
 //! The `renameat2` allows to rename a file.
 
+use super::util::at;
 use crate::errno::Errno;
 use crate::file;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
-use crate::file::vfs::ResolutionSettings;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -15,6 +17,8 @@ const RENAME_NOREPLACE: c_int = 1;
 /// Flag: Exchanges old and new paths atomically.
 const RENAME_EXCHANGE: c_int = 2;
 
+// TODO implement flags
+
 #[syscall]
 pub fn renameat2(
 	olddirfd: c_int,
@@ -23,36 +27,50 @@ pub fn renameat2(
 	newpath: SyscallString,
 	_flags: c_int,
 ) -> Result<i32, Errno> {
-	let (old_mutex, new_parent_mutex, new_name, rs) = {
+	let (fds_mutex, oldpath, newpath, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
+
+		let rs = ResolutionSettings::for_process(&*proc, false);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
 
+		let fds_mutex = proc.file_descriptors.clone().unwrap();
+
 		let oldpath = oldpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let old = super::util::get_file_at(proc, olddirfd, oldpath, false, 0)?;
+		let oldpath = PathBuf::try_from(oldpath)?;
 
-		let proc = proc_mutex.lock();
 		let newpath = newpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let (new_parent, new_name) =
-			super::util::get_parent_at_with_name(proc, newdirfd, newpath, false, 0)?;
+		let newpath = PathBuf::try_from(newpath)?;
 
-		let rs = ResolutionSettings::for_process(&proc, false);
-		(old, new_parent, new_name, rs)
+		(fds_mutex, oldpath, newpath, rs)
 	};
 
+	let fds = fds_mutex.lock();
+
+	let Resolved::Found(old_mutex) = at::get_file(&fds, rs, olddirfd, &oldpath, 0)? else {
+		return Err(errno!(ENOENT));
+	};
 	let mut old = old_mutex.lock();
 	// Cannot rename mountpoint
 	if old.is_mountpoint() {
 		return Err(errno!(EBUSY));
 	}
 
-	let mut new_parent = new_parent_mutex.lock();
+	// TODO RENAME_NOREPLACE
+	let Resolved::Creatable {
+		parent: new_parent,
+		name: new_name,
+	} = at::get_file(&fds, rs, newdirfd, &newpath, 0)?
+	else {
+		return Err(errno!(EEXIST));
+	};
+	let mut new_parent = new_parent.lock();
 
 	// TODO Check permissions if sticky bit is set
 

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -27,8 +27,6 @@ pub fn renameat2(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let ap = proc.access_profile;
-
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
 
@@ -49,6 +47,11 @@ pub fn renameat2(
 	};
 
 	let mut old = old_mutex.lock();
+	// Cannot rename mountpoint
+	if old.is_mountpoint() {
+		return Err(errno!(EBUSY));
+	}
+
 	let mut new_parent = new_parent_mutex.lock();
 
 	// TODO Check permissions if sticky bit is set

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -3,12 +3,12 @@
 use crate::errno::Errno;
 use crate::file;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileType;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use core::ffi::c_int;
 use macros::syscall;
-use crate::file::vfs::ResolutionSettings;
 
 /// Flag: Don't replace new path if it exists. Return an error instead.
 const RENAME_NOREPLACE: c_int = 1;

--- a/src/syscall/renameat2.rs
+++ b/src/syscall/renameat2.rs
@@ -8,6 +8,7 @@ use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use core::ffi::c_int;
 use macros::syscall;
+use crate::file::vfs::ResolutionSettings;
 
 /// Flag: Don't replace new path if it exists. Return an error instead.
 const RENAME_NOREPLACE: c_int = 1;
@@ -22,7 +23,7 @@ pub fn renameat2(
 	newpath: SyscallString,
 	_flags: c_int,
 ) -> Result<i32, Errno> {
-	let (old_mutex, new_parent_mutex, new_name, ap) = {
+	let (old_mutex, new_parent_mutex, new_name, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -43,7 +44,8 @@ pub fn renameat2(
 		let (new_parent, new_name) =
 			super::util::get_parent_at_with_name(proc, newdirfd, newpath, false, 0)?;
 
-		(old, new_parent, new_name, ap)
+		let rs = ResolutionSettings::for_process(&proc, false);
+		(old, new_parent, new_name, rs)
 	};
 
 	let mut old = old_mutex.lock();
@@ -59,18 +61,18 @@ pub fn renameat2(
 		// Create link at new location
 		// The `..` entry is already updated by the file system since having the same
 		// directory in several locations is not allowed
-		vfs::create_link(&mut old, &new_parent, &new_name, &ap)?;
+		vfs::create_link(&mut old, &new_parent, &new_name, &rs.access_profile)?;
 
 		if old.get_type() != FileType::Directory {
-			vfs::remove_file(&mut old, &ap)?;
+			vfs::remove_file(&mut old, &rs.access_profile)?;
 		}
 	} else {
 		// Old and new are on different filesystems.
 
 		// TODO On fail, undo
 
-		file::util::copy_file(&mut old, &mut new_parent, new_name)?;
-		file::util::remove_recursive(&mut old, &ap)?;
+		file::util::copy_file(&mut old, &mut new_parent, new_name, &rs)?;
+		file::util::remove_recursive(&mut old, &rs)?;
 	}
 
 	Ok(0)

--- a/src/syscall/rmdir.rs
+++ b/src/syscall/rmdir.rs
@@ -24,7 +24,6 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, rs)
 	};

--- a/src/syscall/rmdir.rs
+++ b/src/syscall/rmdir.rs
@@ -19,7 +19,8 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
 
-		let path = Path::from_str(pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?, true)?;
+		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, proc.access_profile)

--- a/src/syscall/rmdir.rs
+++ b/src/syscall/rmdir.rs
@@ -3,7 +3,7 @@
 //! If no link remain to the directory, the function also removes it.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
@@ -23,7 +23,7 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 		let mem_space_guard = mem_space.lock();
 
 		let path = pathname.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		(path, rs)
 	};
@@ -32,16 +32,16 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 	{
 		// Get directory
 		let file_mutex = vfs::get_file_from_path(&path, &rs)?;
-		let mut file = file_mutex.lock();
-
+		let file = file_mutex.lock();
+		// Validation
 		match file.get_content() {
 			// The 2 entries in question are `.` and `..`
 			FileContent::Directory(entries) if entries.len() > 2 => return Err(errno!(ENOTEMPTY)),
 			FileContent::Directory(_) => {}
 			_ => return Err(errno!(ENOTDIR)),
 		}
-
-		vfs::remove_file_from_path(path, &rs)?;
+		// Remove
+		vfs::remove_file_from_path(&path, &rs)?;
 	}
 
 	Ok(0)

--- a/src/syscall/rmdir.rs
+++ b/src/syscall/rmdir.rs
@@ -5,6 +5,7 @@
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -12,9 +13,11 @@ use macros::syscall;
 
 #[syscall]
 pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
-	let (path, ap) = {
+	let (path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
+
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
@@ -23,13 +26,13 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
-		(path, proc.access_profile)
+		(path, rs)
 	};
 
 	// Remove the directory
 	{
 		// Get directory
-		let file_mutex = vfs::get_file_from_path(&path, &ap, true)?;
+		let file_mutex = vfs::get_file_from_path(&path, &rs)?;
 		let mut file = file_mutex.lock();
 
 		match file.get_content() {
@@ -38,7 +41,7 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 			_ => return Err(errno!(ENOTDIR)),
 		}
 
-		vfs::remove_file(&mut file, &ap)?;
+		vfs::remove_file(&mut file, &rs.access_profile)?;
 	}
 
 	Ok(0)

--- a/src/syscall/rmdir.rs
+++ b/src/syscall/rmdir.rs
@@ -35,12 +35,13 @@ pub fn rmdir(pathname: SyscallString) -> Result<i32, Errno> {
 		let mut file = file_mutex.lock();
 
 		match file.get_content() {
+			// The 2 entries in question are `.` and `..`
 			FileContent::Directory(entries) if entries.len() > 2 => return Err(errno!(ENOTEMPTY)),
 			FileContent::Directory(_) => {}
 			_ => return Err(errno!(ENOTDIR)),
 		}
 
-		vfs::remove_file(&mut file, &rs.access_profile)?;
+		vfs::remove_file_from_path(path, &rs)?;
 	}
 
 	Ok(0)

--- a/src/syscall/socket.rs
+++ b/src/syscall/socket.rs
@@ -37,7 +37,7 @@ pub fn socket(domain: c_int, r#type: c_int, protocol: c_int) -> Result<i32, Errn
 
 	// Get file
 	let loc = buffer::register(None, sock)?;
-	let file = vfs::get_file_by_location(&loc)?;
+	let file = vfs::get_file_from_location(&loc)?;
 
 	let open_file = OpenFile::new(file, open_file::O_RDWR)?;
 

--- a/src/syscall/socketpair.rs
+++ b/src/syscall/socketpair.rs
@@ -45,7 +45,7 @@ pub fn socketpair(
 
 	let sock = Socket::new(desc)?;
 	let loc = buffer::register(None, sock)?;
-	let file = vfs::get_file_by_location(&loc)?;
+	let file = vfs::get_file_from_location(&loc)?;
 
 	let open_file0 = OpenFile::new(file.clone(), open_file::O_RDONLY)?;
 	let open_file1 = OpenFile::new(file, open_file::O_WRONLY)?;

--- a/src/syscall/statfs.rs
+++ b/src/syscall/statfs.rs
@@ -20,7 +20,7 @@ pub fn statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> Result<i32, Errno
 		let mem_space_guard = mem_space.lock();
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::from_str(path, true)?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, proc.access_profile)

--- a/src/syscall/statfs.rs
+++ b/src/syscall/statfs.rs
@@ -21,7 +21,6 @@ pub(super) fn do_statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> EResult
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, false);
 		(path, rs)

--- a/src/syscall/statfs.rs
+++ b/src/syscall/statfs.rs
@@ -3,7 +3,7 @@
 use crate::errno;
 use crate::errno::{EResult, Errno};
 use crate::file::fs::Statfs;
-use crate::file::path::Path;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
 use crate::process::mem_space::ptr::SyscallPtr;
@@ -20,7 +20,7 @@ pub(super) fn do_statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> EResult
 		let mem_space_guard = mem_space.lock();
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::new(path)?;
+		let path = PathBuf::try_from(path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, false);
 		(path, rs)

--- a/src/syscall/statfs.rs
+++ b/src/syscall/statfs.rs
@@ -1,18 +1,18 @@
 //! The `statfs` system call returns information about a mounted file system.
 
 use crate::errno;
-use crate::errno::Errno;
+use crate::errno::{EResult, Errno};
 use crate::file::fs::Statfs;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::process::mem_space::ptr::SyscallPtr;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use macros::syscall;
 
-#[syscall]
-pub fn statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> Result<i32, Errno> {
-	let (path, ap) = {
+pub(super) fn do_statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> EResult<i32> {
+	let (path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
@@ -23,24 +23,28 @@ pub fn statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> Result<i32, Errno
 		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
-		(path, proc.access_profile)
+		let rs = ResolutionSettings::for_process(&proc, false);
+		(path, rs)
 	};
 
-	let file_mutex = vfs::get_file_from_path(&path, &ap, true)?;
-	let file = file_mutex.lock();
+	let stat = {
+		let file_mutex = vfs::get_file_from_path(&path, &rs)?;
+		let file = file_mutex.lock();
 
-	let mountpoint_mutex = file.get_location().get_mountpoint().unwrap();
-	let mountpoint = mountpoint_mutex.lock();
+		// Unwrapping will not fail since the file is accessed from path
+		let mountpoint_mutex = file.get_location().get_mountpoint().unwrap();
+		let mountpoint = mountpoint_mutex.lock();
 
-	let io_mutex = mountpoint.get_source().get_io()?;
-	let mut io = io_mutex.lock();
+		let io_mutex = mountpoint.get_source().get_io()?;
+		let mut io = io_mutex.lock();
 
-	let fs_mutex = mountpoint.get_filesystem();
-	let fs = fs_mutex.lock();
+		let fs_mutex = mountpoint.get_filesystem();
+		let fs = fs_mutex.lock();
 
-	let stat = fs.get_stat(&mut *io)?;
+		fs.get_stat(&mut *io)?
+	};
 
-	// Writing the statfs structure to userspace
+	// Write structure to userspace
 	{
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
@@ -55,4 +59,9 @@ pub fn statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> Result<i32, Errno
 	}
 
 	Ok(0)
+}
+
+#[syscall]
+pub fn statfs(path: SyscallString, buf: SyscallPtr<Statfs>) -> Result<i32, Errno> {
+	do_statfs(path, buf)
 }

--- a/src/syscall/statfs64.rs
+++ b/src/syscall/statfs64.rs
@@ -1,63 +1,15 @@
 //! The `statfs64` system call returns information about a mounted file system.
 
-use crate::errno;
+use super::statfs::do_statfs;
 use crate::errno::Errno;
 use crate::file::fs::Statfs;
-use crate::file::path::Path;
-use crate::file::vfs;
 use crate::process::mem_space::ptr::SyscallPtr;
 use crate::process::mem_space::ptr::SyscallString;
-use crate::process::Process;
 use macros::syscall;
-
-// TODO Streamline with `[f]statfs`
 
 // TODO Check args types
 #[syscall]
 pub fn statfs64(path: SyscallString, _sz: usize, buf: SyscallPtr<Statfs>) -> Result<i32, Errno> {
 	// TODO Use `sz`
-
-	let (path, ap) = {
-		let proc_mutex = Process::current_assert();
-		let proc = proc_mutex.lock();
-
-		let mem_space = proc.get_mem_space().unwrap();
-		let mem_space_guard = mem_space.lock();
-
-		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
-
-		(path, proc.access_profile)
-	};
-
-	let file_mutex = vfs::get_file_from_path(&path, &ap, true)?;
-	let file = file_mutex.lock();
-
-	let mountpoint_mutex = file.get_location().get_mountpoint().unwrap();
-	let mountpoint = mountpoint_mutex.lock();
-
-	let io_mutex = mountpoint.get_source().get_io()?;
-	let mut io = io_mutex.lock();
-
-	let fs_mutex = mountpoint.get_filesystem();
-	let fs = fs_mutex.lock();
-
-	let stat = fs.get_stat(&mut *io)?;
-
-	// Writing the statfs structure to userspace
-	{
-		let proc_mutex = Process::current_assert();
-		let proc = proc_mutex.lock();
-
-		let mem_space = proc.get_mem_space().unwrap();
-		let mut mem_space_guard = mem_space.lock();
-
-		let buf = buf
-			.get_mut(&mut mem_space_guard)?
-			.ok_or_else(|| errno!(EFAULT))?;
-		*buf = stat;
-	}
-
-	Ok(0)
+	do_statfs(path, buf)
 }

--- a/src/syscall/statfs64.rs
+++ b/src/syscall/statfs64.rs
@@ -25,7 +25,7 @@ pub fn statfs64(path: SyscallString, _sz: usize, buf: SyscallPtr<Statfs>) -> Res
 		let mem_space_guard = mem_space.lock();
 
 		let path = path.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
-		let path = Path::from_str(path, true)?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, proc.access_profile)

--- a/src/syscall/statx.rs
+++ b/src/syscall/statx.rs
@@ -102,10 +102,10 @@ pub fn statx(
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
 
-		let pathname = pathname
+		let path = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		util::get_file_at(proc, dirfd, pathname, true, flags)?
+		util::get_file_at(proc, dirfd, path, true, flags)?
 	};
 	let file = file_mutex.lock();
 

--- a/src/syscall/statx.rs
+++ b/src/syscall/statx.rs
@@ -101,7 +101,7 @@ pub fn statx(
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let rs = ResolutionSettings::for_process(&*proc, true);
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();

--- a/src/syscall/symlink.rs
+++ b/src/syscall/symlink.rs
@@ -1,20 +1,22 @@
 //! The `symlink` syscall allows to create a symbolic link.
 
 use crate::errno::Errno;
-use crate::file::path::Path;
+use crate::file::path::{Path, PathBuf};
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::FileContent;
 use crate::limits;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
-use crate::util::container::string::String;
 use macros::syscall;
 
 #[syscall]
 pub fn symlink(target: SyscallString, linkpath: SyscallString) -> Result<i32, Errno> {
-	let (target, linkpath, ap) = {
+	let (target, linkpath, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
+
+		let rs = ResolutionSettings::for_process(&proc, true);
 
 		let mem_space = proc.get_mem_space().unwrap();
 		let mem_space_guard = mem_space.lock();
@@ -25,14 +27,14 @@ pub fn symlink(target: SyscallString, linkpath: SyscallString) -> Result<i32, Er
 		if target_slice.len() > limits::SYMLINK_MAX {
 			return Err(errno!(ENAMETOOLONG));
 		}
-		let target = String::try_from(target_slice)?;
+		let target = PathBuf::try_from(target_slice)?;
 
 		let linkpath = linkpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let linkpath = Path::new(linkpath)?;
+		let linkpath = PathBuf::try_from(linkpath)?;
 
-		(target, linkpath, proc.access_profile)
+		(target, linkpath, rs)
 	};
 
 	// Get the path of the parent directory
@@ -41,13 +43,13 @@ pub fn symlink(target: SyscallString, linkpath: SyscallString) -> Result<i32, Er
 	let name = linkpath.file_name().ok_or_else(|| errno!(ENOENT))?;
 
 	// The parent directory
-	let parent_mutex = vfs::get_file_from_path(parent_path, &ap, true)?;
+	let parent_mutex = vfs::get_file_from_path(parent_path, &rs)?;
 	let mut parent = parent_mutex.lock();
 
 	vfs::create_file(
 		&mut parent,
 		name.try_into()?,
-		&ap,
+		&rs.access_profile,
 		0o777,
 		FileContent::Link(target),
 	)?;

--- a/src/syscall/symlink.rs
+++ b/src/syscall/symlink.rs
@@ -30,21 +30,27 @@ pub fn symlink(target: SyscallString, linkpath: SyscallString) -> Result<i32, Er
 		let linkpath = linkpath
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let linkpath = Path::from_str(linkpath, true)?;
+		let linkpath = Path::new(linkpath)?;
 
 		(target, linkpath, proc.access_profile)
 	};
 
 	// Get the path of the parent directory
-	let mut parent_path = linkpath;
+	let parent_path = linkpath.parent().unwrap_or(Path::root());
 	// The file's basename
-	let name = parent_path.pop().ok_or_else(|| errno!(ENOENT))?;
+	let name = linkpath.file_name().ok_or_else(|| errno!(ENOENT))?;
 
 	// The parent directory
-	let parent_mutex = vfs::get_file_from_path(&parent_path, &ap, true)?;
+	let parent_mutex = vfs::get_file_from_path(parent_path, &ap, true)?;
 	let mut parent = parent_mutex.lock();
 
-	vfs::create_file(&mut parent, name, &ap, 0o777, FileContent::Link(target))?;
+	vfs::create_file(
+		&mut parent,
+		name.try_into()?,
+		&ap,
+		0o777,
+		FileContent::Link(target),
+	)?;
 
 	Ok(0)
 }

--- a/src/syscall/symlinkat.rs
+++ b/src/syscall/symlinkat.rs
@@ -34,7 +34,6 @@ pub fn symlinkat(
 	let linkpath = linkpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-
 	util::create_file_at(proc, newdirfd, linkpath, 0, file_content, true, 0)?;
 
 	Ok(0)

--- a/src/syscall/symlinkat.rs
+++ b/src/syscall/symlinkat.rs
@@ -21,7 +21,7 @@ pub fn symlinkat(
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
-	let rs = ResolutionSettings::for_process(&*proc, true);
+	let rs = ResolutionSettings::for_process(&proc, true);
 
 	let mem_space = proc.get_mem_space().unwrap().clone();
 	let mem_space_guard = mem_space.lock();
@@ -44,7 +44,7 @@ pub fn symlinkat(
 	let linkpath = Path::new(linkpath)?;
 
 	// Create link
-	let resolved = at::get_file(&*fds, rs, newdirfd, linkpath, 0)?;
+	let resolved = at::get_file(&fds, rs.clone(), newdirfd, linkpath, 0)?;
 	match resolved {
 		Resolved::Creatable {
 			parent,

--- a/src/syscall/symlinkat.rs
+++ b/src/syscall/symlinkat.rs
@@ -2,11 +2,11 @@
 
 use super::util;
 use crate::errno::Errno;
+use crate::file::path::PathBuf;
 use crate::file::FileContent;
 use crate::limits;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
-use crate::util::container::string::String;
 use core::ffi::c_int;
 use macros::syscall;
 
@@ -28,7 +28,7 @@ pub fn symlinkat(
 	if target_slice.len() > limits::SYMLINK_MAX {
 		return Err(errno!(ENAMETOOLONG));
 	}
-	let target = String::try_from(target_slice)?;
+	let target = PathBuf::try_from(target_slice)?;
 	let file_content = FileContent::Link(target);
 
 	let linkpath = linkpath

--- a/src/syscall/symlinkat.rs
+++ b/src/syscall/symlinkat.rs
@@ -1,9 +1,11 @@
 //! The `symlinkat` syscall allows to create a symbolic link.
 
-use super::util;
+use super::util::at;
 use crate::errno::Errno;
+use crate::file::path::Path;
 use crate::file::path::PathBuf;
-use crate::file::FileContent;
+use crate::file::vfs::{ResolutionSettings, Resolved};
+use crate::file::{vfs, FileContent};
 use crate::limits;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
@@ -19,8 +21,13 @@ pub fn symlinkat(
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
+	let rs = ResolutionSettings::for_process(&*proc, true);
+
 	let mem_space = proc.get_mem_space().unwrap().clone();
 	let mem_space_guard = mem_space.lock();
+
+	let fds_mutex = proc.file_descriptors.clone().unwrap();
+	let fds = fds_mutex.lock();
 
 	let target_slice = target
 		.get(&mem_space_guard)?
@@ -34,7 +41,21 @@ pub fn symlinkat(
 	let linkpath = linkpath
 		.get(&mem_space_guard)?
 		.ok_or_else(|| errno!(EFAULT))?;
-	util::create_file_at(proc, newdirfd, linkpath, 0, file_content, true, 0)?;
+	let linkpath = Path::new(linkpath)?;
+
+	// Create link
+	let resolved = at::get_file(&*fds, rs, newdirfd, linkpath, 0)?;
+	match resolved {
+		Resolved::Creatable {
+			parent,
+			name,
+		} => {
+			let mut parent = parent.lock();
+			let name = name.try_into()?;
+			vfs::create_file(&mut parent, name, &rs.access_profile, 0, file_content)?;
+		}
+		Resolved::Found(_) => return Err(errno!(EEXIST)),
+	}
 
 	Ok(0)
 }

--- a/src/syscall/truncate.rs
+++ b/src/syscall/truncate.rs
@@ -21,7 +21,7 @@ pub fn truncate(path: SyscallString, length: usize) -> Result<i32, Errno> {
 	let path = path.get(&mem_space)?.ok_or(errno!(EFAULT))?;
 	let path = Path::new(path)?;
 
-	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
+	let file_mutex = vfs::get_file_from_path(path, &rs)?;
 	let mut file = file_mutex.lock();
 	file.set_size(length as _);
 

--- a/src/syscall/truncate.rs
+++ b/src/syscall/truncate.rs
@@ -3,6 +3,7 @@
 use crate::errno::Errno;
 use crate::file::path::Path;
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use macros::syscall;
@@ -12,6 +13,8 @@ pub fn truncate(path: SyscallString, length: usize) -> Result<i32, Errno> {
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
+	let rs = ResolutionSettings::for_process(&proc, true);
+
 	let mem_space_mutex = proc.get_mem_space().unwrap();
 	let mem_space = mem_space_mutex.lock();
 
@@ -19,7 +22,7 @@ pub fn truncate(path: SyscallString, length: usize) -> Result<i32, Errno> {
 	let path = Path::new(path)?;
 	let path = super::util::get_absolute_path(&proc, path)?;
 
-	let file_mutex = vfs::get_file_from_path(&path, &proc.access_profile, true)?;
+	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
 	let mut file = file_mutex.lock();
 	file.set_size(length as _);
 

--- a/src/syscall/truncate.rs
+++ b/src/syscall/truncate.rs
@@ -20,7 +20,6 @@ pub fn truncate(path: SyscallString, length: usize) -> Result<i32, Errno> {
 
 	let path = path.get(&mem_space)?.ok_or(errno!(EFAULT))?;
 	let path = Path::new(path)?;
-	let path = super::util::get_absolute_path(&proc, path)?;
 
 	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
 	let mut file = file_mutex.lock();

--- a/src/syscall/truncate.rs
+++ b/src/syscall/truncate.rs
@@ -15,7 +15,8 @@ pub fn truncate(path: SyscallString, length: usize) -> Result<i32, Errno> {
 	let mem_space_mutex = proc.get_mem_space().unwrap();
 	let mem_space = mem_space_mutex.lock();
 
-	let path = Path::from_str(path.get(&mem_space)?.ok_or(errno!(EFAULT))?, true)?;
+	let path = path.get(&mem_space)?.ok_or(errno!(EFAULT))?;
+	let path = Path::new(path)?;
 	let path = super::util::get_absolute_path(&proc, path)?;
 
 	let file_mutex = vfs::get_file_from_path(&path, &proc.access_profile, true)?;

--- a/src/syscall/umount.rs
+++ b/src/syscall/umount.rs
@@ -3,8 +3,9 @@
 
 use crate::errno;
 use crate::errno::Errno;
-use crate::file::mountpoint;
 use crate::file::path::Path;
+use crate::file::vfs::ResolutionSettings;
+use crate::file::{mountpoint, vfs};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use macros::syscall;
@@ -14,11 +15,24 @@ pub fn umount(target: SyscallString) -> Result<i32, Errno> {
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
+	// Check permission
+	if !proc.access_profile.is_privileged() {
+		return Err(errno!(EPERM));
+	}
+
+	let rs = ResolutionSettings::for_process(&proc, true);
+
 	let mem_space = proc.get_mem_space().unwrap();
 	let mem_space_guard = mem_space.lock();
+
+	// Get target directory
 	let target_slice = target.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
 	let target_path = Path::new(target_slice)?;
-	mountpoint::remove(&target_path)?;
+	let target_dir = vfs::get_file_from_path(target_path, &rs)?;
+	let target_dir = target_dir.lock();
+
+	// Remove mountpoint
+	mountpoint::remove(target_dir.get_location())?;
 
 	Ok(0)
 }

--- a/src/syscall/umount.rs
+++ b/src/syscall/umount.rs
@@ -14,13 +14,10 @@ pub fn umount(target: SyscallString) -> Result<i32, Errno> {
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
-	// Getting a slice to the string
 	let mem_space = proc.get_mem_space().unwrap();
 	let mem_space_guard = mem_space.lock();
 	let target_slice = target.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
-
-	// Getting the mountpoint
-	let target_path = Path::from_str(target_slice, true)?;
+	let target_path = Path::new(target_slice)?;
 	mountpoint::remove(&target_path)?;
 
 	Ok(0)

--- a/src/syscall/unlink.rs
+++ b/src/syscall/unlink.rs
@@ -20,7 +20,6 @@ pub fn unlink(pathname: SyscallString) -> Result<i32, Errno> {
 		let mem_space = mem_space_mutex.lock();
 		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
 		let path = Path::new(path)?;
-		let path = super::util::get_absolute_path(&proc, path)?;
 
 		let rs = ResolutionSettings::for_process(&proc, true);
 		(path, rs)

--- a/src/syscall/unlink.rs
+++ b/src/syscall/unlink.rs
@@ -17,7 +17,8 @@ pub fn unlink(pathname: SyscallString) -> Result<i32, Errno> {
 
 		let mem_space_mutex = proc.get_mem_space().unwrap();
 		let mem_space = mem_space_mutex.lock();
-		let path = Path::from_str(pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?, true)?;
+		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
+		let path = Path::new(path)?;
 		let path = super::util::get_absolute_path(&proc, path)?;
 
 		(path, proc.access_profile)

--- a/src/syscall/unlink.rs
+++ b/src/syscall/unlink.rs
@@ -12,23 +12,18 @@ use macros::syscall;
 
 #[syscall]
 pub fn unlink(pathname: SyscallString) -> Result<i32, Errno> {
-	let (path, rs) = {
-		let proc_mutex = Process::current_assert();
-		let proc = proc_mutex.lock();
+	let proc_mutex = Process::current_assert();
+	let proc = proc_mutex.lock();
 
-		let mem_space_mutex = proc.get_mem_space().unwrap();
-		let mem_space = mem_space_mutex.lock();
-		let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
-		let path = Path::new(path)?;
+	let mem_space_mutex = proc.get_mem_space().unwrap();
+	let mem_space = mem_space_mutex.lock();
+	let path = pathname.get(&mem_space)?.ok_or(errno!(EFAULT))?;
+	let path = Path::new(path)?;
 
-		let rs = ResolutionSettings::for_process(&proc, true);
-		(path, rs)
-	};
+	let rs = ResolutionSettings::for_process(&proc, true);
 
 	// Remove the file
-	let file_mutex = vfs::get_file_from_path(&path, &rs)?;
-	let mut file = file_mutex.lock();
-	vfs::remove_file(&mut file, &rs.access_profile)?;
+	vfs::remove_file_from_path(path, &rs)?;
 
 	Ok(0)
 }

--- a/src/syscall/unlinkat.rs
+++ b/src/syscall/unlinkat.rs
@@ -2,9 +2,11 @@
 //!
 //! If no link remain to the file, the function also removes it.
 
-use super::util;
+use super::util::at;
 use crate::errno::Errno;
+use crate::file::path::PathBuf;
 use crate::file::vfs;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use core::ffi::c_int;
@@ -12,24 +14,38 @@ use macros::syscall;
 
 #[syscall]
 pub fn unlinkat(dirfd: c_int, pathname: SyscallString, flags: c_int) -> Result<i32, Errno> {
-	let (file_mutex, ap) = {
+	let (fds_mutex, path, rs) = {
 		let proc_mutex = Process::current_assert();
 		let proc = proc_mutex.lock();
 
-		let ap = proc.access_profile;
+		let rs = ResolutionSettings::for_process(&*proc, false);
 
 		let mem_space = proc.get_mem_space().unwrap().clone();
 		let mem_space_guard = mem_space.lock();
+
+		let fds_mutex = proc.file_descriptors.clone().unwrap();
+
 		let pathname = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-		let file = util::get_file_at(proc, dirfd, pathname, false, flags)?;
+		let path = PathBuf::try_from(pathname)?;
 
-		(file, ap)
+		(fds_mutex, path, rs)
 	};
 
-	let mut file = file_mutex.lock();
-	vfs::remove_file(&mut file, &ap)?;
+	let fds = fds_mutex.lock();
+
+	let parent_path = path.parent().ok_or_else(|| errno!(ENOENT))?;
+	let name = path.file_name().ok_or_else(|| errno!(ENOENT))?;
+
+	let resolved = at::get_file(&fds, rs, dirfd, &path, flags)?;
+	match resolved {
+		Resolved::Found(parent_mutex) => {
+			let mut parent = parent_mutex.lock();
+			vfs::remove_file(&mut parent, name, &rs.access_profile)?;
+		}
+		_ => return Err(errno!(ENOENT)),
+	}
 
 	Ok(0)
 }

--- a/src/syscall/unlinkat.rs
+++ b/src/syscall/unlinkat.rs
@@ -23,7 +23,6 @@ pub fn unlinkat(dirfd: c_int, pathname: SyscallString, flags: c_int) -> Result<i
 		let pathname = pathname
 			.get(&mem_space_guard)?
 			.ok_or_else(|| errno!(EFAULT))?;
-
 		let file = util::get_file_at(proc, dirfd, pathname, false, flags)?;
 
 		(file, ap)

--- a/src/syscall/util.rs
+++ b/src/syscall/util.rs
@@ -5,6 +5,7 @@ use crate::errno::EResult;
 use crate::errno::{AllocResult, CollectResult};
 use crate::file::path::{Path, PathBuf};
 use crate::file::vfs;
+use crate::file::vfs::ResolutionSettings;
 use crate::file::File;
 use crate::file::FileContent;
 use crate::file::Mode;
@@ -19,7 +20,6 @@ use crate::util::lock::Mutex;
 use crate::util::lock::MutexGuard;
 use crate::util::ptr::arc::Arc;
 use core::mem::size_of;
-use crate::file::vfs::ResolutionSettings;
 
 /// Returns the absolute path according to the process's current working
 /// directory.

--- a/src/syscall/util.rs
+++ b/src/syscall/util.rs
@@ -28,9 +28,8 @@ use core::mem::size_of;
 /// - `path` is the path.
 pub fn get_absolute_path(process: &Process, path: &Path) -> AllocResult<PathBuf> {
 	process
-		.chroot
+		.cwd
 		.components()
-		.chain(process.cwd.components())
 		.chain(path.components())
 		.collect::<CollectResult<PathBuf>>()
 		.0

--- a/src/syscall/util.rs
+++ b/src/syscall/util.rs
@@ -2,7 +2,6 @@
 
 use crate::errno;
 use crate::errno::EResult;
-use crate::errno::{AllocResult, CollectResult};
 use crate::file::path::{Path, PathBuf};
 use crate::file::vfs;
 use crate::file::vfs::ResolutionSettings;
@@ -20,22 +19,6 @@ use crate::util::lock::Mutex;
 use crate::util::lock::MutexGuard;
 use crate::util::ptr::arc::Arc;
 use core::mem::size_of;
-
-/// Returns the absolute path according to the process's current working
-/// directory.
-///
-/// Arguments:
-/// - `process` is the process.
-/// - `path` is the path.
-pub fn get_absolute_path(process: &Process, path: &Path) -> AllocResult<PathBuf> {
-	process
-		.cwd
-		.0
-		.components()
-		.chain(path.components())
-		.collect::<CollectResult<PathBuf>>()
-		.0
-}
 
 // TODO Find a safer and cleaner solution
 /// Checks that the given array of strings at pointer `ptr` is accessible to
@@ -246,7 +229,7 @@ pub fn create_file_at(
 /// resume. In which case, the current function handles the execution flow
 /// accordingly.
 ///
-/// The functions locks the mutex of the current process. Thus, the caller must
+/// The function locks the mutex of the current process. Thus, the caller must
 /// ensure the mutex isn't already locked to prevent a deadlock.
 ///
 /// If returning, the function returns the mutex lock of the current process.
@@ -291,7 +274,7 @@ pub fn handle_proc_state() {
 /// If interrupted, the function doesn't return and the control flow jumps
 /// directly to handling the signal.
 ///
-/// The functions locks the mutex of the current process. Thus, the caller must
+/// The function locks the mutex of the current process. Thus, the caller must
 /// ensure the mutex isn't already locked to prevent a deadlock.
 ///
 /// `regs` is the registers state passed to the current syscall.
@@ -303,7 +286,7 @@ pub fn signal_check(regs: &Regs) {
 		// Returning the system call early to resume it later
 		let mut r = regs.clone();
 		// TODO Clean
-		r.eip -= 2; // TODO Handle the case where the instruction insn't two bytes long (sysenter)
+		r.eip -= 2; // TODO Handle the case where the instruction isn't two bytes long (sysenter)
 		proc.regs = r;
 		proc.syscalling = false;
 

--- a/src/syscall/util/at.rs
+++ b/src/syscall/util/at.rs
@@ -1,0 +1,95 @@
+//! `*at` system calls allow to perform operations on files without having to redo the whole
+//! path-resolution each time.
+//!
+//! This module implements utility functions for those system calls.
+
+use crate::errno::EResult;
+use crate::file::fd::FileDescriptorTable;
+use crate::file::path::Path;
+use crate::file::vfs::{ResolutionSettings, Resolved};
+use crate::file::{vfs, FileLocation};
+use core::ffi::c_int;
+
+/// Special value to be used as file descriptor, telling to take the path relative to the
+/// current working directory.
+pub const AT_FDCWD: c_int = -100;
+
+/// Flag: If pathname is a symbolic link, do not dereference it: instead return
+/// information about the link itself.
+pub const AT_SYMLINK_NOFOLLOW: c_int = 0x100;
+/// Flag: Perform access checks using the effective user and group IDs.
+pub const AT_EACCESS: c_int = 0x200;
+/// Flag: If pathname is a symbolic link, dereference it.
+pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
+/// Flag: Don't automount the terminal component of `pathname` if it is a directory that is an
+/// automount point.
+pub const AT_NO_AUTOMOUNT: c_int = 0x800;
+/// Flag: If `pathname` is an empty string, operate on the file referred to by `dirfd`.
+pub const AT_EMPTY_PATH: c_int = 0x1000;
+/// Flag: Do whatever `stat` does.
+pub const AT_STATX_SYNC_AS_STAT: c_int = 0x0000;
+/// Flag: Force the attributes to be synchronized with the server.
+pub const AT_STATX_FORCE_SYNC: c_int = 0x2000;
+/// Flag: Don't synchronize anything, but rather take cached information.
+pub const AT_STATX_DONT_SYNC: c_int = 0x4000;
+
+/// Returns the location of the file pointed to by the given file descriptor.
+///
+/// Arguments:
+/// - `fds` is the file descriptors table
+/// - `fd` is the file descriptor
+///
+/// If the given file descriptor is invalid, the function returns [`errno::EBADF`].
+fn fd_to_loc(fds: &FileDescriptorTable, fd: c_int) -> EResult<FileLocation> {
+	if fd < 0 {
+		return Err(errno!(EBADF));
+	}
+	let open_file_mutex = fds
+		.get_fd(fd as _)
+		.ok_or(errno!(EBADF))?
+		.get_open_file()
+		.clone();
+	let open_file = open_file_mutex.lock();
+	Ok(open_file.get_location().clone())
+}
+
+/// Returns the file for the given path `path`.
+///
+/// Arguments:
+/// - `fds` is the file descriptors table to use
+/// - `rs` is the path resolution settings to use
+/// - `dirfd` is the file descriptor of the parent directory
+/// - `path` is the path relative to the parent directory
+/// - `flags` is the set of `AT_*` flags
+///
+/// **Note**: the `start` field of [`ResolutionSettings`] is used as the current working
+/// directory.
+pub fn get_file<'p>(
+	fds: &FileDescriptorTable,
+	mut rs: ResolutionSettings,
+	dirfd: c_int,
+	path: &'p Path,
+	flags: c_int,
+) -> EResult<Resolved<'p>> {
+	// Prepare resolution settings
+	let follow_links = if rs.follow_link {
+		flags & AT_SYMLINK_NOFOLLOW == 0
+	} else {
+		flags & AT_SYMLINK_FOLLOW != 0
+	};
+	rs.follow_link = follow_links;
+	// If not starting from current directory, get location
+	if dirfd != AT_FDCWD {
+		rs.start = fd_to_loc(fds, dirfd)?;
+	}
+	if path.is_empty() {
+		// Validation
+		if flags & AT_EMPTY_PATH == 0 {
+			return Err(errno!(ENOENT));
+		}
+		let file = vfs::get_file_from_location(&rs.start)?;
+		Ok(Resolved::Found(file))
+	} else {
+		vfs::resolve_path(path, &rs)
+	}
+}

--- a/src/syscall/util/mod.rs
+++ b/src/syscall/util/mod.rs
@@ -1,4 +1,6 @@
-//! This module implements utility functions for system calls.
+//! Utility functions for system calls.
+
+pub mod at;
 
 use crate::errno;
 use crate::errno::EResult;
@@ -127,102 +129,5 @@ pub fn signal_check(regs: &Regs) {
 		drop(proc_mutex);
 
 		handle_proc_state();
-	}
-}
-
-/// `*at` system calls allow to perform operations on files without having to redo the whole
-/// path-resolution each time.
-///
-/// This module implements utility functions for those system calls.
-pub mod at {
-	use crate::errno::EResult;
-	use crate::file::fd::FileDescriptorTable;
-	use crate::file::path::Path;
-	use crate::file::vfs::{ResolutionSettings, Resolved};
-	use crate::file::{vfs, FileLocation};
-	use core::ffi::c_int;
-
-	/// Special value to be used as file descriptor, telling to take the path relative to the
-	/// current working directory.
-	pub const AT_FDCWD: c_int = -100;
-
-	/// Flag: If pathname is a symbolic link, do not dereference it: instead return
-	/// information about the link itself.
-	pub const AT_SYMLINK_NOFOLLOW: c_int = 0x100;
-	/// Flag: Perform access checks using the effective user and group IDs.
-	pub const AT_EACCESS: c_int = 0x200;
-	/// Flag: If pathname is a symbolic link, dereference it.
-	pub const AT_SYMLINK_FOLLOW: c_int = 0x400;
-	/// Flag: Don't automount the terminal component of `pathname` if it is a directory that is an
-	/// automount point.
-	pub const AT_NO_AUTOMOUNT: c_int = 0x800;
-	/// Flag: If `pathname` is an empty string, operate on the file referred to by `dirfd`.
-	pub const AT_EMPTY_PATH: c_int = 0x1000;
-	/// Flag: Do whatever `stat` does.
-	pub const AT_STATX_SYNC_AS_STAT: c_int = 0x0000;
-	/// Flag: Force the attributes to be synchronized with the server.
-	pub const AT_STATX_FORCE_SYNC: c_int = 0x2000;
-	/// Flag: Don't synchronize anything, but rather take cached information.
-	pub const AT_STATX_DONT_SYNC: c_int = 0x4000;
-
-	/// Returns the location of the file pointed to by the given file descriptor.
-	///
-	/// Arguments:
-	/// - `fds` is the file descriptors table
-	/// - `fd` is the file descriptor
-	///
-	/// If the given file descriptor is invalid, the function returns [`errno::EBADF`].
-	fn fd_to_loc(fds: &FileDescriptorTable, fd: c_int) -> EResult<FileLocation> {
-		if fd < 0 {
-			return Err(errno!(EBADF));
-		}
-		let open_file_mutex = fds
-			.get_fd(fd as _)
-			.ok_or(errno!(EBADF))?
-			.get_open_file()
-			.clone();
-		let open_file = open_file_mutex.lock();
-		Ok(open_file.get_location().clone())
-	}
-
-	/// Returns the file for the given path `path`.
-	///
-	/// Arguments:
-	/// - `fds` is the file descriptors table to use
-	/// - `rs` is the path resolution settings to use
-	/// - `dirfd` is the file descriptor of the parent directory
-	/// - `path` is the path relative to the parent directory
-	/// - `flags` is the set of `AT_*` flags
-	///
-	/// **Note**: the `start` field of [`ResolutionSettings`] is used as the current working
-	/// directory.
-	pub fn get_file<'p>(
-		fds: &FileDescriptorTable,
-		mut rs: ResolutionSettings,
-		dirfd: c_int,
-		path: &'p Path,
-		flags: c_int,
-	) -> EResult<Resolved<'p>> {
-		// Prepare resolution settings
-		let follow_links = if rs.follow_link {
-			flags & AT_SYMLINK_NOFOLLOW == 0
-		} else {
-			flags & AT_SYMLINK_FOLLOW != 0
-		};
-		rs.follow_link = follow_links;
-		// If not starting from current directory, get location
-		if dirfd != AT_FDCWD {
-			rs.start = fd_to_loc(fds, dirfd)?;
-		}
-		if path.is_empty() {
-			// Validation
-			if flags & AT_EMPTY_PATH == 0 {
-				return Err(errno!(ENOENT));
-			}
-			let file = vfs::get_file_from_location(&rs.start)?;
-			Ok(Resolved::Found(file))
-		} else {
-			vfs::resolve_path(path, &rs)
-		}
 	}
 }

--- a/src/syscall/utimensat.rs
+++ b/src/syscall/utimensat.rs
@@ -1,14 +1,14 @@
 //! The `utimensat` system call allows to change the timestamps of a file.
 
-use super::util;
+use super::util::at;
 use crate::errno::Errno;
-use crate::file::File;
+use crate::file::path::Path;
+use crate::file::vfs::{ResolutionSettings, Resolved};
 use crate::process::mem_space::ptr::SyscallPtr;
 use crate::process::mem_space::ptr::SyscallString;
 use crate::process::Process;
 use crate::time::unit::TimeUnit;
 use crate::time::unit::Timespec;
-use crate::util::lock::Mutex;
 use core::ffi::c_int;
 use macros::syscall;
 
@@ -22,38 +22,32 @@ pub fn utimensat(
 	let proc_mutex = Process::current_assert();
 	let proc = proc_mutex.lock();
 
+	let rs = ResolutionSettings::for_process(&proc, true);
+
 	let mem_space = proc.get_mem_space().unwrap().clone();
 	let mem_space_guard = mem_space.lock();
 
-	let times_val = times.get(&mem_space_guard)?.ok_or(errno!(EFAULT))?;
+	let fds = proc.file_descriptors.as_ref().unwrap().lock();
+
+	let pathname = pathname
+		.get(&mem_space_guard)?
+		.ok_or_else(|| errno!(EFAULT))?;
+	let pathname = Path::new(pathname)?;
+
+	let times_val = times.get(&mem_space_guard)?.ok_or_else(|| errno!(EFAULT))?;
 	let atime = times_val[0];
 	let mtime = times_val[1];
 
-	let set = |file_mutex: &Mutex<File>| {
-		let mut file = file_mutex.lock();
-		// TODO clean
-		file.atime = atime.to_nano() / 1000000000;
-		file.mtime = mtime.to_nano() / 1000000000;
-		// TODO sync only when required
-		file.sync()
+	let Resolved::Found(file_mutex) = at::get_file(&fds, rs, dirfd, pathname, flags)? else {
+		return Err(errno!(ENOENT));
 	};
+	let mut file = file_mutex.lock();
 
-	match pathname.get(&mem_space_guard)? {
-		Some(pathname) => {
-			let file_mutex = util::get_file_at(proc, dirfd, pathname, true, flags)?;
-			set(&file_mutex)?;
-		}
-		None if dirfd != AT_FDCWD => {
-			if dirfd < 0 {
-				return Err(errno!(EBADF));
-			}
+	// TODO clean
+	file.atime = atime.to_nano() / 1000000000;
+	file.mtime = mtime.to_nano() / 1000000000;
+	// TODO sync only when required
+	file.sync()?;
 
-			let fds = proc.file_descriptors.as_ref().unwrap().lock();
-			let fd = fds.get_fd(dirfd as _).ok_or(errno!(EBADF))?;
-			let open_file = fd.get_open_file().lock();
-			set(open_file.get_file())?;
-		}
-		_ => return Err(errno!(EFAULT)),
-	}
 	Ok(0)
 }

--- a/src/syscall/utimensat.rs
+++ b/src/syscall/utimensat.rs
@@ -1,6 +1,5 @@
 //! The `utimensat` system call allows to change the timestamps of a file.
 
-use super::access::AT_FDCWD;
 use super::util;
 use crate::errno::Errno;
 use crate::file::File;

--- a/src/util/container/hashmap.rs
+++ b/src/util/container/hashmap.rs
@@ -53,7 +53,6 @@ impl Hasher for XORHasher {
 ///
 /// Since hashing function have collisions, several elements can have the same
 /// hash.
-#[derive(Debug)]
 struct Bucket<K: Eq + Hash, V> {
 	/// The vector storing the key/value pairs.
 	elements: Vec<(K, V)>,
@@ -146,7 +145,6 @@ impl<K: Eq + Hash + TryClone<Error = E>, V: TryClone<Error = E>, E: From<AllocEr
 }
 
 /// Structure representing a hashmap.
-#[derive(Debug)]
 pub struct HashMap<K: Eq + Hash, V> {
 	/// The number of buckets in the hashmap.
 	buckets_count: usize,
@@ -463,18 +461,15 @@ impl<'m, K: Hash + Eq, V> FusedIterator for Iter<'m, K, V> {}
 
 unsafe impl<'m, K: Hash + Eq, V> TrustedLen for Iter<'m, K, V> {}
 
-impl<K: Eq + Hash + fmt::Display, V: fmt::Display> fmt::Display for HashMap<K, V> {
+impl<K: Eq + Hash + fmt::Debug, V: fmt::Debug> fmt::Debug for HashMap<K, V> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "[")?;
-
 		for (i, (key, value)) in self.iter().enumerate() {
-			write!(f, "{}: {}", key, value)?;
-
+			write!(f, "{key:?}: {value:?}")?;
 			if i + 1 < self.len() {
 				write!(f, ", ")?;
 			}
 		}
-
 		write!(f, "]")
 	}
 }

--- a/src/util/container/string.rs
+++ b/src/util/container/string.rs
@@ -257,6 +257,16 @@ impl FromIterator<u8> for CollectResult<String> {
 	}
 }
 
+impl<'c> FromIterator<&'c u8> for CollectResult<String> {
+	fn from_iter<T: IntoIterator<Item = &'c u8>>(iter: T) -> Self {
+		Self(
+			CollectResult::<Vec<u8>>::from_iter(iter)
+				.0
+				.map(String::from),
+		)
+	}
+}
+
 // TODO Iterators
 
 impl Debug for String {

--- a/src/util/container/string.rs
+++ b/src/util/container/string.rs
@@ -1,6 +1,6 @@
 //! This module implements the String structure which wraps the `str` type.
 
-use crate::errno::AllocResult;
+use crate::errno::{AllocResult, CollectResult};
 use crate::util::container::vec::Vec;
 use crate::util::AllocError;
 use crate::util::TryClone;
@@ -128,6 +128,14 @@ impl String {
 	}
 }
 
+impl From<Vec<u8>> for String {
+	fn from(data: Vec<u8>) -> Self {
+		Self {
+			data,
+		}
+	}
+}
+
 impl TryFrom<&[u8]> for String {
 	type Error = AllocError;
 
@@ -236,6 +244,16 @@ impl TryClone for String {
 		Ok(Self {
 			data: self.data.try_clone()?,
 		})
+	}
+}
+
+impl FromIterator<u8> for CollectResult<String> {
+	fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
+		Self(
+			CollectResult::<Vec<u8>>::from_iter(iter)
+				.0
+				.map(String::from),
+		)
 	}
 }
 

--- a/src/util/container/vec.rs
+++ b/src/util/container/vec.rs
@@ -426,6 +426,12 @@ impl<T> FromIterator<T> for CollectResult<Vec<T>> {
 	}
 }
 
+impl<'a, T: 'a + Clone> FromIterator<&'a T> for CollectResult<Vec<T>> {
+	fn from_iter<I: IntoIterator<Item = &'a T>>(iter: I) -> Self {
+		CollectResult::<Vec<T>>::from_iter(iter.into_iter().cloned())
+	}
+}
+
 impl<T> AsRef<[T]> for Vec<T> {
 	fn as_ref(&self) -> &[T] {
 		self.as_slice()

--- a/src/util/lock/mod.rs
+++ b/src/util/lock/mod.rs
@@ -23,6 +23,8 @@ pub mod spinlock;
 use crate::idt;
 use crate::util::lock::spinlock::Spinlock;
 use core::cell::UnsafeCell;
+use core::fmt;
+use core::fmt::Formatter;
 use core::ops::Deref;
 use core::ops::DerefMut;
 
@@ -203,6 +205,13 @@ impl<T, const INT: bool> Mutex<T, INT> {
 }
 
 unsafe impl<T, const INT: bool> Sync for Mutex<T, INT> {}
+
+impl<T: ?Sized + fmt::Debug, const INT: bool> fmt::Debug for Mutex<T, INT> {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		let guard = self.lock();
+		fmt::Debug::fmt(&*guard, f)
+	}
+}
 
 /// Type alias on `Mutex` representing a mutex which blocks interrupts.
 pub type IntMutex<T> = Mutex<T, false>;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -125,17 +125,22 @@ impl<T: Default + Sized> TryDefault for T {
 	}
 }
 
-/// Wrapper structure allowing to implement the Display trait on the [u8] type
+/// Wrapper structure allowing to implement the [`core::fmt::Display`] trait on the [u8] type
 /// to display it as a string.
 pub struct DisplayableStr<'a>(pub &'a [u8]);
 
 impl<'a> fmt::Display for DisplayableStr<'a> {
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		for b in self.0 {
 			fmt.write_char(*b as char)?;
 		}
-
 		Ok(())
+	}
+}
+
+impl<'a> fmt::Debug for DisplayableStr<'a> {
+	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+		fmt::Debug::fmt(self, fmt)
 	}
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -140,7 +140,7 @@ impl<'a> fmt::Display for DisplayableStr<'a> {
 
 impl<'a> fmt::Debug for DisplayableStr<'a> {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt::Display::fmt(self, fmt)
+		write!(fmt, "\"{self}\"")
 	}
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -140,7 +140,7 @@ impl<'a> fmt::Display for DisplayableStr<'a> {
 
 impl<'a> fmt::Debug for DisplayableStr<'a> {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		fmt::Debug::fmt(self, fmt)
+		fmt::Display::fmt(self, fmt)
 	}
 }
 


### PR DESCRIPTION
- Provide two separate types (`PathBuf` and `Path`) to allow holding paths by reference instead of always owning them (which implies cloning, and thus allocating memory)
- Rewrite the path resolution algorithm for correctness
- Partially cleanup `*at` system calls
- Remove useless helper functions