### PR TITLE
fix: run with `--release`

### DIFF
--- a/kernel/src/device/storage/nvme.rs
+++ b/kernel/src/device/storage/nvme.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 use core::{
 	any::Any,
-	array, fmt,
+	fmt,
 	fmt::Formatter,
 	hint,
 	hint::unlikely,
@@ -593,19 +593,29 @@ struct QueuePairInner {
 	cq_head: u32,
 
 	completion_phase: bool,
-	/// Associated data for each submission entry
-	entries: [QueueEntry; SQ_LEN],
+	/// Associated data for each submission entry.
+	///
+	/// Heap-allocated to avoid a stack overflow.
+	entries: Box<[QueueEntry; SQ_LEN]>,
 }
 
-impl Default for QueuePairInner {
-	fn default() -> Self {
-		Self {
+impl QueuePairInner {
+	fn new() -> AllocResult<Self> {
+		let mut entries = Box::<MaybeUninit<[QueueEntry; SQ_LEN]>>::new_uninit()?;
+		// Init on heap to avoid stack overflow
+		let elem_ptr = entries.as_mut_ptr() as *mut QueueEntry;
+		for i in 0..SQ_LEN {
+			unsafe {
+				elem_ptr.add(i).write(QueueEntry::Empty);
+			}
+		}
+		Ok(Self {
 			sq_tail: 0,
 			cq_head: 0,
 
 			completion_phase: true,
-			entries: array::from_fn::<_, SQ_LEN, _>(|_| QueueEntry::Empty),
-		}
+			entries: unsafe { entries.assume_init() },
+		})
 	}
 }
 
@@ -627,7 +637,25 @@ impl QueuePair {
 	pub fn new(id: u16) -> AllocResult<Self> {
 		// A SQE (64 bytes) is four times larger than a CQE (16 bytes)
 		let sq = buddy::alloc_kernel(2, 0)?;
-		let cq = buddy::alloc_kernel(0, 0)?; // TODO on failure, free previous
+		let cq = match buddy::alloc_kernel(0, 0) {
+			Ok(p) => p,
+			Err(e) => {
+				unsafe {
+					buddy::free_kernel(sq.as_ptr(), 2);
+				}
+				return Err(e);
+			}
+		};
+		let inner = match QueuePairInner::new() {
+			Ok(i) => i,
+			Err(e) => {
+				unsafe {
+					buddy::free_kernel(cq.as_ptr(), 0);
+					buddy::free_kernel(sq.as_ptr(), 2);
+				}
+				return Err(e);
+			}
+		};
 		// Zero-initialize queues
 		unsafe {
 			NonNull::slice_from_raw_parts(sq, PAGE_SIZE << 2)
@@ -644,7 +672,7 @@ impl QueuePair {
 			cq: cq.cast(),
 
 			sem: Semaphore::new(SQ_LEN),
-			inner: Default::default(),
+			inner: Spin::new(inner),
 		})
 	}
 }
@@ -985,9 +1013,11 @@ impl Controller {
 			println!("nvme: fatal error during initialization");
 			return Err(errno!(EINVAL));
 		}
-		// Identify controller
-		let mut ctrlr_id: MaybeUninit<IdentifyController> = MaybeUninit::uninit();
-		let dptr = VirtAddr::from(&mut ctrlr_id).kernel_to_physical().unwrap();
+		// Identify controller. Heap-allocated to avoid stack overflow
+		let mut ctrlr_id = Box::<MaybeUninit<IdentifyController>>::new_uninit()?;
+		let dptr = VirtAddr::from(ctrlr_id.as_mut_ptr())
+			.kernel_to_physical()
+			.unwrap();
 		let cqe = inner.submit_cmd_sync(
 			&inner.admin_qp,
 			SubmissionQueueEntry {
@@ -1027,9 +1057,12 @@ impl Controller {
 				inner.bar.read::<u32>(REG_CC) | (subsize << 16) | (comsize << 20),
 			);
 		}
-		// List namespaces
-		let mut ns_ids: MaybeUninit<[u32; 1024]> = MaybeUninit::uninit();
-		let dptr = VirtAddr::from(&mut ns_ids).kernel_to_physical().unwrap();
+		drop(ctrlr_id);
+		// List namespaces. heap-allocated to avoid a stack overflow
+		let mut ns_ids = Box::<MaybeUninit<[u32; 1024]>>::new_uninit()?;
+		let dptr = VirtAddr::from(ns_ids.as_mut_ptr())
+			.kernel_to_physical()
+			.unwrap();
 		let cqe = inner.submit_cmd_sync(
 			&inner.admin_qp,
 			SubmissionQueueEntry {
@@ -1054,7 +1087,7 @@ impl Controller {
 		};
 		controller.inner.init_io_queue(1, 1)?;
 		let ns_ids = unsafe { ns_ids.assume_init() };
-		for i in ns_ids {
+		for &i in ns_ids.iter() {
 			if i == 0 {
 				break;
 			}

--- a/kernel/src/memory/malloc/mod.rs
+++ b/kernel/src/memory/malloc/mod.rs
@@ -21,7 +21,11 @@
 mod block;
 mod chunk;
 
-use crate::{memory, memory::malloc::ptr::NonNull, sync::spin::IntSpin};
+use crate::{
+	memory,
+	memory::{buddy, malloc::ptr::NonNull},
+	sync::spin::IntSpin,
+};
 use block::Block;
 use chunk::Chunk;
 use core::{
@@ -32,7 +36,7 @@ use core::{
 	ptr,
 	ptr::drop_in_place,
 };
-use utils::errno::AllocResult;
+use utils::{errno::AllocResult, limits::PAGE_SIZE};
 
 /// The allocator's spinlock.
 static SPINLOCK: IntSpin<()> = IntSpin::new(());
@@ -129,6 +133,14 @@ unsafe fn free(ptr: NonNull<u8>) {
 	super::trace::sample("malloc", super::trace::SampleOp::Free, ptr.as_ptr() as _, 0);
 }
 
+/// Returns the buddy [`buddy::FrameOrder`] required to satisfy `layout` when the allocation goes
+/// through the buddy allocator (because the required alignment exceeds [`chunk::ALIGNMENT`]).
+fn buddy_order_for(layout: Layout) -> buddy::FrameOrder {
+	let bytes = layout.size().max(layout.align());
+	let pages = bytes.div_ceil(PAGE_SIZE);
+	buddy::get_order(NonZeroUsize::new(pages).unwrap())
+}
+
 /// See Rust documentation.
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
@@ -136,7 +148,11 @@ pub unsafe fn __alloc(layout: Layout) -> AllocResult<NonNull<[u8]>> {
 	let Some(size) = NonZeroUsize::new(layout.size()) else {
 		return Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0));
 	};
-	let ptr = alloc(size)?;
+	let ptr = if layout.align() <= chunk::ALIGNMENT {
+		alloc(size)?
+	} else {
+		buddy::alloc_kernel(buddy_order_for(layout), 0)?
+	};
 	Ok(NonNull::slice_from_raw_parts(ptr, size.get()))
 }
 
@@ -152,8 +168,21 @@ pub unsafe fn __realloc(
 		__dealloc(ptr, old_layout);
 		return Ok(NonNull::slice_from_raw_parts(new_layout.dangling(), 0));
 	};
-	let ptr = realloc(ptr, new_size)?;
-	Ok(NonNull::slice_from_raw_parts(ptr, new_size.get()))
+	let old_buddy = old_layout.align() > chunk::ALIGNMENT;
+	let new_buddy = new_layout.align() > chunk::ALIGNMENT;
+	let new_ptr = if !old_buddy && !new_buddy {
+		// Both allocations live in the chunk allocator: try in-place resize
+		realloc(ptr, new_size)?
+	} else {
+		// At least one side requires the buddy allocator
+		let new_ptr = __alloc(new_layout)?;
+		let new_ptr = new_ptr.cast::<u8>();
+		let copy_len = old_layout.size().min(new_size.get());
+		ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), copy_len);
+		__dealloc(ptr, old_layout);
+		new_ptr
+	};
+	Ok(NonNull::slice_from_raw_parts(new_ptr, new_size.get()))
 }
 
 /// See Rust documentation.
@@ -163,7 +192,11 @@ pub unsafe fn __dealloc(ptr: NonNull<u8>, layout: Layout) {
 	if unlikely(layout.size() == 0) {
 		return;
 	}
-	free(ptr);
+	if layout.align() <= chunk::ALIGNMENT {
+		free(ptr);
+	} else {
+		buddy::free_kernel(ptr.as_ptr(), buddy_order_for(layout));
+	}
 }
 
 #[cfg(test)]

--- a/utils/src/boxed.rs
+++ b/utils/src/boxed.rs
@@ -25,7 +25,7 @@ use core::{
 	fmt,
 	marker::Unsize,
 	mem,
-	mem::ManuallyDrop,
+	mem::{ManuallyDrop, MaybeUninit},
 	ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn},
 	ptr::{Unique, drop_in_place},
 };
@@ -62,6 +62,28 @@ impl<T> Box<T> {
 			mem::forget(self);
 			t
 		}
+	}
+}
+
+impl<T> Box<MaybeUninit<T>> {
+	/// Allocates uninitialized storage for a `T` on the heap.
+	pub fn new_uninit() -> AllocResult<Self> {
+		let layout = Layout::new::<MaybeUninit<T>>();
+		if layout.size() == 0 {
+			return Ok(Self(Unique::dangling()));
+		}
+		let ptr = unsafe { __alloc(layout)?.cast() };
+		Ok(Self(Unique::from_non_null(ptr)))
+	}
+
+	/// Converts to `Box<T>`.
+	///
+	/// # Safety
+	///
+	/// The caller must ensure the value is initialized.
+	pub unsafe fn assume_init(self) -> Box<T> {
+		let raw = Box::into_raw(self) as *mut T;
+		unsafe { Box::from_raw(raw) }
 	}
 }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -103,7 +103,7 @@ extern crate alloc as rust_alloc;
 
 #[cfg(any(feature = "std", test))]
 #[unsafe(no_mangle)]
-fn __alloc(layout: Layout) -> AllocResult<NonNull<[u8]>> {
+unsafe fn __alloc(layout: Layout) -> AllocResult<NonNull<[u8]>> {
 	use rust_alloc::alloc::{Allocator, Global};
 	Global.allocate(layout)
 }


### PR DESCRIPTION
Fix crash when booting a release mode kernel.

The NVMe driver was producing a kernel stack overflow by having large, page-aligned structures on stack. Fixed by allocating on the heap.

The PR features a fix for memory allocations with an alignment of more than 16 bytes. Above this threshold, the allocator now directly uses the buddy allocator.