### PR TITLE
ci: migrate book building to GitHub Infrastructure, add GH Actions CodeQL analysis

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -40,3 +40,8 @@ jobs:
         run: mdbook-mermaid install doc/
       - name: Build book
         run: mdbook build doc/
+      - name: Upload book artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: book
+          path: doc/book

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - name: Cache mdbook binary
         id: cache-mdbook
         uses: actions/cache@v5
@@ -27,19 +28,17 @@ jobs:
           path: ~/.cargo/bin/mdbook-mermaid
           key: mdbook-mermaid-0.17.0-${{ runner.os }}
       - name: Install mdbook
-        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
         if: steps.cache-mdbook.outputs.cache-hit != 'true'
-        with:
-          tool: mdbook@0.5.2
+        run: cargo +stable install mdbook@0.5.2
       - name: Install mdbook-mermaid
-        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
         if: steps.cache-mdbook-mermaid.outputs.cache-hit != 'true'
-        with:
-          tool: mdbook-mermaid@0.17.0
+        run: cargo +stable install mdbook-mermaid@0.17.0
+
       - name: Prepare
         run: mdbook-mermaid install doc/
       - name: Build book
         run: mdbook build doc/
+
       - name: Upload book artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,42 @@
+name: Book
+on:
+  push:
+    branches: ["master"]
+    paths: ["doc/**"]
+  pull_request:
+    paths: ["doc/**"]
+
+jobs:
+  build:
+    name: Build
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache mdbook binary
+        id: cache-mdbook
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/mdbook
+          key: mdbook-0.5.2-${{ runner.os }}
+      - name: Cache mdbook-mermaid binary
+        id: cache-mdbook-mermaid
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/mdbook-mermaid
+          key: mdbook-mermaid-0.17.0-${{ runner.os }}
+      - name: Install mdbook
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        if: steps.cache-mdbook.outputs.cache-hit != 'true'
+        with:
+          tool: mdbook@0.5.2
+      - name: Install mdbook-mermaid
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        if: steps.cache-mdbook-mermaid.outputs.cache-hit != 'true'
+        with:
+          tool: mdbook-mermaid@0.17.0
+      - name: Prepare
+        run: mdbook-mermaid install doc/
+      - name: Build book
+        run: mdbook build doc/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,14 +39,6 @@ jobs:
       - name: Integration tests
         working-directory: inttest
         run: cargo fmt --check
-  book:
-    runs-on: [self-hosted, linux]
-    needs: clippy
-    steps:
-      - name: Prepare
-        run: mdbook-mermaid install doc/
-      - name: Build book
-        run: mdbook build doc/
   documentation:
     runs-on: [self-hosted, linux]
     needs: clippy

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,34 @@
+name: "CodeQL (Actions)"
+
+on:
+  push:
+    branches: ["master"]
+    paths: &paths
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["master"]
+    paths: *paths
+  schedule:
+    - cron: "33 4 * * 0"
+
+jobs:
+  analyze:
+    permissions:
+      security-events: write
+    runs-on: "ubuntu-latest"
+    name: Analyze
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:actions"


### PR DESCRIPTION
- Migrate Maestro Book build to GitHub Infrastructure
- Improvement: Build book only when changes occurred in the `doc/` folder
- Misc: Upload book artifact, allowing to download it for 90 days
- Add GitHub Actions CodeQL analysis to enhance pipelines security