### PR TITLE
ci: migrate to github infrastructure & 5x speedup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,6 +108,41 @@ jobs:
         run: cargo miri test
         timeout-minutes: 10
 
+  selftest:
+    name: Self Test (${{ matrix.arch }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: [lint, build-binutils]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["x86", "x86_64"]
+    steps:
+      - uses: actions/checkout@v6
+      - *rust-toolchain-cache
+      - *rust-registry-cache
+      - &apt-cache
+        name: Retrieve APT dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: bash build-essential clang curl grub-pc-bin libssl-dev lld mtools perl pkg-config qemu-system texinfo xorriso
+          version: 1.0
+      - *binutils-cache
+      - &binutils-path
+        name: Add binutils to PATH
+        run: echo "$(pwd)/built-binutils/usr/bin" >> $GITHUB_PATH
+      - name: Run utils tests
+        working-directory: utils
+        run: cargo test
+        timeout-minutes: 3
+      - name: Run kernel tests
+        working-directory: kernel
+        env:
+          CARGOFLAGS: --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
+        run: ci/test.sh self
+        timeout-minutes: 3
+
   build:
     name: Build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
     permissions:
@@ -130,15 +165,8 @@ jobs:
         uses: actions/cache@v5
         with: *rust-registry-cache-params
       - *binutils-cache
-      - &binutils-path
-        name: Add binutils to PATH
-        run: echo "$(pwd)/built-binutils/usr/bin" >> $GITHUB_PATH
-      - &apt-cache
-        name: Retrieve APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
-        with:
-          packages: bash build-essential clang curl grub-pc-bin libssl-dev lld mtools perl pkg-config qemu-system texinfo xorriso
-          version: 1.0
+      - *binutils-path
+      - *apt-cache
       - name: Build
         working-directory: kernel
         run: cargo build --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json --profile ${{ matrix.profile.name }}
@@ -193,34 +221,6 @@ jobs:
           ARCH: ${{ matrix.arch }}
           PROFILE: ${{ matrix.profile }}
         run: ../build
-
-  selftest:
-    name: Self Test (${{ matrix.arch }})
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ["x86", "x86_64"]
-    steps:
-      - uses: actions/checkout@v6
-      - *rust-toolchain-cache
-      - *rust-registry-cache
-      - *apt-cache
-      - *binutils-cache
-      - *binutils-path
-      - name: Run utils tests
-        working-directory: utils
-        run: cargo test
-        timeout-minutes: 3
-      - name: Run kernel tests
-        working-directory: kernel
-        env:
-          CARGOFLAGS: --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
-        run: ci/test.sh self
-        timeout-minutes: 3
 
   build_inttest:
     name: Build Integration Tests Disks (${{ matrix.arch.kernel }})

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,28 +1,25 @@
 name: Check
 on:
   push:
-    branches:
-      - master
+    branches: ["master"]
   pull_request:
+
 jobs:
   clippy:
-    runs-on: [self-hosted, linux]
+    name: Lint & Check Format (${{ matrix.dir }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ["macros", "utils", "kernel", "inttest"]
     steps:
-      - uses: actions/checkout@v4
-      - name: Macros
-        working-directory: macros
+      - uses: actions/checkout@v6
+      - name: Clippy
+        working-directory: ${{ matrix.dir }}
         run: cargo clippy --all-features --all-targets -- -D warnings
-      - name: Utils
-        working-directory: utils
-        run: cargo clippy --all-features --all-targets -- -D warnings
-      - name: Kernel
-        working-directory: kernel
-        run: |
-          cp default.build-config.toml build-config.toml
-          cargo clippy --all-features --all-targets -- -D warnings
-      - name: Integration tests
-        working-directory: inttest
-        run: cargo clippy --all-features --all-targets -- -D warnings
+
   format:
     runs-on: [self-hosted, linux]
     needs: clippy
@@ -39,6 +36,7 @@ jobs:
       - name: Integration tests
         working-directory: inttest
         run: cargo fmt --check
+
   documentation:
     runs-on: [self-hosted, linux]
     needs: clippy
@@ -50,6 +48,7 @@ jobs:
       - name: Build references
         working-directory: kernel
         run: cargo doc --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
+
   build:
     name: build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
     runs-on: [self-hosted, linux]
@@ -70,6 +69,7 @@ jobs:
       - name: Check Multiboot2
         working-directory: kernel
         run: grub-file --is-x86-multiboot2 target/${{ matrix.arch }}/${{ matrix.profile.dir }}/maestro
+
   miri:
     runs-on: [self-hosted, linux]
     needs: build
@@ -80,6 +80,7 @@ jobs:
           MIRIFLAGS: -Zmiri-disable-stacked-borrows
         run: cargo miri test
         timeout-minutes: 10
+
   module:
     runs-on: [self-hosted, linux]
     needs: build
@@ -106,6 +107,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
           PROFILE: ${{ matrix.profile }}
         run: ../build
+
   selftest:
     runs-on: [self-hosted, linux]
     needs: module
@@ -124,6 +126,7 @@ jobs:
           CARGOFLAGS: --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
         run: ci/test.sh self
         timeout-minutes: 10
+
   build_inttest:
     name: build_inttest (${{ matrix.arch.kernel }})
     runs-on: [self-hosted, linux]
@@ -155,6 +158,7 @@ jobs:
         run: |
           ./build.sh
           mv disk disk-${{ matrix.arch.kernel }}-compat
+
   inttest:
     name: inttest (${{ matrix.arch.kernel }}, ${{ matrix.cores }} CPU(s), ${{ matrix.disktype }})
     runs-on: [self-hosted, linux]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: Restore binutils cache
+      - &binutils-cache
+        name: Restore binutils cache
         id: cache-binutils
         uses: actions/cache@v5
         with:
@@ -71,9 +72,11 @@ jobs:
         run: cargo doc --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
 
   build:
-    name: build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
-    runs-on: [self-hosted, linux]
-    needs: lint
+    name: Build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: [lint, build-binutils]
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +87,15 @@ jobs:
           - name: "release"
             dir: "release"
     steps:
+      - uses: actions/checkout@v6
+      - *binutils-cache
+      - name: Add binutils to PATH
+        run: echo "$(pwd)/built-binutils/usr/bin" >> $GITHUB_PATH
+      - name: Retrieve APT dependencies
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: bash build-essential clang curl grub-pc-bin libssl-dev lld perl pkg-config qemu-system texinfo xorriso
+          version: 1.0
       - name: Build
         working-directory: kernel
         run: cargo build --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json --profile ${{ matrix.profile.name }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -107,10 +107,11 @@ jobs:
       - &binutils-path
         name: Add binutils to PATH
         run: echo "$(pwd)/built-binutils/usr/bin" >> $GITHUB_PATH
-      - name: Retrieve APT dependencies
+      - &apt-cache
+        name: Retrieve APT dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: bash build-essential clang curl grub-pc-bin libssl-dev lld perl pkg-config qemu-system texinfo xorriso
+          packages: bash build-essential clang curl grub-pc-bin libssl-dev lld mtools perl pkg-config qemu-system texinfo xorriso
           version: 1.0
       - name: Build
         working-directory: kernel
@@ -166,13 +167,20 @@ jobs:
         run: ../build
 
   selftest:
-    runs-on: [self-hosted, linux]
-    needs: module
+    name: Self Test (${{ matrix.arch }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
         arch: ["x86", "x86_64"]
     steps:
+      - uses: actions/checkout@v6
+      - *apt-cache
+      - *binutils-cache
+      - *binutils-path
       - name: Run utils tests
         working-directory: utils
         run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  clippy:
+  lint:
     name: Lint & Check Format (${{ matrix.dir }})
     permissions:
       contents: read
@@ -19,27 +19,13 @@ jobs:
       - name: Clippy
         working-directory: ${{ matrix.dir }}
         run: cargo clippy --all-features --all-targets -- -D warnings
-
-  format:
-    runs-on: [self-hosted, linux]
-    needs: clippy
-    steps:
-      - name: Macros
-        working-directory: macros
-        run: cargo fmt --check
-      - name: Utils
-        working-directory: utils
-        run: cargo fmt --check
-      - name: Kernel
-        working-directory: kernel
-        run: cargo fmt --check
-      - name: Integration tests
-        working-directory: inttest
+      - name: Check Format
+        working-directory: ${{ matrix.dir }}
         run: cargo fmt --check
 
   documentation:
     runs-on: [self-hosted, linux]
-    needs: clippy
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +38,7 @@ jobs:
   build:
     name: build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
     runs-on: [self-hosted, linux]
-    needs: clippy
+    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,6 +48,24 @@ jobs:
         dir: ["macros", "utils", "kernel", "inttest"]
     steps:
       - uses: actions/checkout@v6
+      - &rust-toolchain-cache
+        name: Cache Rust toolchain
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.rustup/toolchains
+            ~/.rustup/update-hashes
+          key: rust-toolchain-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}
+      - &rust-registry-cache
+        name: Restore Rust registry cache
+        uses: actions/cache/restore@v5
+        with: &rust-registry-cache-params
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: rust-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: rust-registry-${{ runner.os }}-
       - name: Clippy
         working-directory: ${{ matrix.dir }}
         run: cargo clippy --all-features --all-targets -- -D warnings
@@ -67,6 +85,8 @@ jobs:
         arch: ["x86", "x86_64"]
     steps:
       - uses: actions/checkout@v6
+      - *rust-toolchain-cache
+      - *rust-registry-cache
       - name: Build references
         working-directory: kernel
         run: cargo doc --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
@@ -79,6 +99,8 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v6
+      - *rust-toolchain-cache
+      - *rust-registry-cache
       - name: Utils
         working-directory: utils
         env:
@@ -103,6 +125,10 @@ jobs:
             dir: "release"
     steps:
       - uses: actions/checkout@v6
+      - *rust-toolchain-cache
+      - name: Cache Rust registry
+        uses: actions/cache@v5
+        with: *rust-registry-cache-params
       - *binutils-cache
       - &binutils-path
         name: Add binutils to PATH
@@ -147,6 +173,8 @@ jobs:
           name: workspace-${{ matrix.arch }}-${{ matrix.profile }}
       - name: Restore permissions
         run: chmod +x mod/build
+      - *rust-toolchain-cache
+      - *rust-registry-cache
       - *binutils-cache
       - *binutils-path
       - name: Clippy
@@ -178,6 +206,8 @@ jobs:
         arch: ["x86", "x86_64"]
     steps:
       - uses: actions/checkout@v6
+      - *rust-toolchain-cache
+      - *rust-registry-cache
       - *apt-cache
       - *binutils-cache
       - *binutils-path

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -71,6 +71,21 @@ jobs:
         working-directory: kernel
         run: cargo doc --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
 
+  miri:
+    name: Miri
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v6
+      - name: Utils
+        working-directory: utils
+        env:
+          MIRIFLAGS: -Zmiri-disable-stacked-borrows
+        run: cargo miri test
+        timeout-minutes: 10
+
   build:
     name: Build (${{ matrix.arch }}, ${{ matrix.profile.dir }})
     permissions:
@@ -102,17 +117,6 @@ jobs:
       - name: Check Multiboot2
         working-directory: kernel
         run: grub-file --is-x86-multiboot2 target/${{ matrix.arch }}/${{ matrix.profile.dir }}/maestro
-
-  miri:
-    runs-on: [self-hosted, linux]
-    needs: build
-    steps:
-      - name: Utils
-        working-directory: utils
-        env:
-          MIRIFLAGS: -Zmiri-disable-stacked-borrows
-        run: cargo miri test
-        timeout-minutes: 10
 
   module:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -214,13 +214,13 @@ jobs:
       - name: Run utils tests
         working-directory: utils
         run: cargo test
-        timeout-minutes: 10
+        timeout-minutes: 3
       - name: Run kernel tests
         working-directory: kernel
         env:
           CARGOFLAGS: --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json
         run: ci/test.sh self
-        timeout-minutes: 10
+        timeout-minutes: 3
 
   build_inttest:
     name: Build Integration Tests Disks (${{ matrix.arch.kernel }})
@@ -309,7 +309,7 @@ jobs:
         run: |
           mv ../disk-${{ matrix.arch.kernel }} qemu_disk
           ci/test.sh int
-        timeout-minutes: 10
+        timeout-minutes: 3
       - name: Run (compat)
         if: ${{ matrix.arch.user_compat }}
         working-directory: kernel
@@ -320,4 +320,4 @@ jobs:
         run: |
           mv ../disk-${{ matrix.arch.kernel }}-compat qemu_disk
           ci/test.sh int
-        timeout-minutes: 10
+        timeout-minutes: 3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -223,7 +223,7 @@ jobs:
         timeout-minutes: 10
 
   build_inttest:
-    name: Build Integration Tests (${{ matrix.arch.kernel }})
+    name: Build Integration Tests Disks (${{ matrix.arch.kernel }})
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -238,7 +238,8 @@ jobs:
             user: "x86_64-unknown-linux-musl"
             user_compat: "i686-unknown-linux-musl"
     steps:
-      - name: Restore ${{ matrix.arch.kernel }}-debug workspace
+      - &restore-dbg-workspace
+        name: Restore ${{ matrix.arch.kernel }}-debug workspace
         uses: actions/download-artifact@v8
         with:
           name: workspace-${{ matrix.arch.kernel }}-debug
@@ -265,10 +266,17 @@ jobs:
         run: |
           ./build.sh
           mv disk disk-${{ matrix.arch.kernel }}-compat
+      - name: Upload disk images
+        uses: actions/upload-artifact@v7
+        with:
+          name: inttest-disks-${{ matrix.arch.kernel }}
+          path: inttest/disk-${{ matrix.arch.kernel }}*
 
   inttest:
-    name: inttest (${{ matrix.arch.kernel }}, ${{ matrix.cores }} CPU(s), ${{ matrix.disktype }})
-    runs-on: [self-hosted, linux]
+    name: Run Integration Tests (${{ matrix.arch.kernel }}, ${{ matrix.cores }} CPU(s), ${{ matrix.disktype }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
     needs: build_inttest
     strategy:
       fail-fast: false
@@ -282,6 +290,16 @@ jobs:
         cores: ["1", "2"]
         disktype: ["ide", "nvme"]
     steps:
+      - uses: actions/checkout@v6
+      - name: Restore disk images
+        uses: actions/download-artifact@v8
+        with:
+          name: inttest-disks-${{ matrix.arch.kernel }}
+      - *rust-toolchain-cache
+      - *rust-registry-cache
+      - *apt-cache
+      - *binutils-cache
+      - *binutils-path
       - name: Run
         working-directory: kernel
         env:
@@ -289,7 +307,7 @@ jobs:
           QEMUFLAGS: "-smp ${{ matrix.cores }}"
           DISKTYPE: ${{ matrix.disktype }}
         run: |
-          cp ../inttest/disk-${{ matrix.arch.kernel }} qemu_disk
+          mv ../disk-${{ matrix.arch.kernel }} qemu_disk
           ci/test.sh int
         timeout-minutes: 10
       - name: Run (compat)
@@ -300,6 +318,6 @@ jobs:
           QEMUFLAGS: "-smp ${{ matrix.cores }}"
           DISKTYPE: ${{ matrix.disktype }}
         run: |
-          cp ../inttest/disk-${{ matrix.arch.kernel }}-compat qemu_disk
+          mv ../disk-${{ matrix.arch.kernel }}-compat qemu_disk
           ci/test.sh int
         timeout-minutes: 10

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -104,7 +104,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - *binutils-cache
-      - name: Add binutils to PATH
+      - &binutils-path
+        name: Add binutils to PATH
         run: echo "$(pwd)/built-binutils/usr/bin" >> $GITHUB_PATH
       - name: Retrieve APT dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
@@ -117,9 +118,20 @@ jobs:
       - name: Check Multiboot2
         working-directory: kernel
         run: grub-file --is-x86-multiboot2 target/${{ matrix.arch }}/${{ matrix.profile.dir }}/maestro
+      - name: Remove binutils (should not be in workspace artifact)
+        run: rm -rf built-binutils
+      - name: Upload ${{ matrix.arch }}-${{ matrix.profile.dir }} workspace
+        uses: actions/upload-artifact@v7
+        with:
+          name: workspace-${{ matrix.arch }}-${{ matrix.profile.dir }}
+          path: .
+          include-hidden-files: true
 
   module:
-    runs-on: [self-hosted, linux]
+    name: Build Module ${{ matrix.mod }} (${{ matrix.arch }}, ${{ matrix.profile }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       fail-fast: false
@@ -128,6 +140,14 @@ jobs:
         arch: ["x86", "x86_64"]
         profile: ["debug", "release"]
     steps:
+      - name: Restore ${{ matrix.arch }}-${{ matrix.profile }} workspace
+        uses: actions/download-artifact@v8
+        with:
+          name: workspace-${{ matrix.arch }}-${{ matrix.profile }}
+      - name: Restore permissions
+        run: chmod +x mod/build
+      - *binutils-cache
+      - *binutils-path
       - name: Clippy
         working-directory: mod/${{ matrix.mod }}
         env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,13 +24,17 @@ jobs:
         run: cargo fmt --check
 
   documentation:
-    runs-on: [self-hosted, linux]
+    name: Build Documentation (${{ matrix.arch }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
     needs: lint
     strategy:
       fail-fast: false
       matrix:
         arch: ["x86", "x86_64"]
     steps:
+      - uses: actions/checkout@v6
       - name: Build references
         working-directory: kernel
         run: cargo doc --target arch/${{ matrix.arch }}/${{ matrix.arch }}.json

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,37 @@ on:
   pull_request:
 
 jobs:
+  build-binutils:
+    name: Build binutils
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore binutils cache
+        id: cache-binutils
+        uses: actions/cache@v5
+        with:
+          path: built-binutils
+          key: binutils-2.46.0
+      - name: Build binutils
+        if: steps.cache-binutils.outputs.cache-hit != 'true'
+        run: |
+          curl -o binutils.tar.xz https://ftp.gnu.org/gnu/binutils/binutils-2.46.0.tar.xz
+          tar xf binutils.tar.xz
+          rm binutils.tar.xz
+          for target in {i686-elf,x86_64-elf}; do
+            binutils-*/configure \
+              --prefix=/usr \
+              --target="$target" \
+              --disable-werror \
+              --disable-doc \
+              --disable-nls \
+              --enable-64-bit-bfd
+            make -j$(nproc)
+            make DESTDIR="$(pwd)/built-binutils" install
+            make distclean
+          done
+
   lint:
     name: Lint & Check Format (${{ matrix.dir }})
     permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -193,9 +193,11 @@ jobs:
         timeout-minutes: 10
 
   build_inttest:
-    name: build_inttest (${{ matrix.arch.kernel }})
-    runs-on: [self-hosted, linux]
-    needs: module
+    name: Build Integration Tests (${{ matrix.arch.kernel }})
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -206,6 +208,16 @@ jobs:
             user: "x86_64-unknown-linux-musl"
             user_compat: "i686-unknown-linux-musl"
     steps:
+      - name: Restore ${{ matrix.arch.kernel }}-debug workspace
+        uses: actions/download-artifact@v8
+        with:
+          name: workspace-${{ matrix.arch.kernel }}-debug
+      - name: Restore permissions
+        run: chmod +x mod/build inttest/build.sh
+      - *rust-toolchain-cache
+      - *rust-registry-cache
+      - *binutils-cache
+      - *binutils-path
       - name: Build tests
         working-directory: inttest
         env:


### PR DESCRIPTION
Migrate CI to GitHub Infrastructure, using their runners instead of a self-hosted one.

⏩ The speedup is estimated to 5x the elapsed time on a full run in the previous pipeline (6min average in this one VS 30min in the existing one).

This is achieved through multiple things:
- Job parallelization
- Using cache strategies
- Job dependencies ("needs") rework
- `clippy` & `format` jobs were merged in a unique `lint` job

There is some side-effects:
- Run on latest version of Ubuntu available in GitHub runners, instead of Debian Bookworm
- Update APT packages (no longer the ones from the runner at the time its docker image was built, now the ones from the time the cache was created)
- Update binutils from 2.45.0 to 2.46.0
- Now build binutils without locales (`--disable-nls`)
- Reduce timeout from 10 minutes to 3 minutes in some tests steps

Note: This is the end of both repositories:
- https://github.com/maestro-os/github-runner-docker
- https://github.com/maestro-os/jenkins-runner