### PR TITLE
Scheduler/SMP fix

### DIFF
--- a/kernel/src/arch/x86/apic.rs
+++ b/kernel/src/arch/x86/apic.rs
@@ -264,7 +264,7 @@ pub fn redirect_int(gsi: u32, lapic: u32, int: u8) -> bool {
 		ioapic_write(
 			ioapic.mmio.as_ptr(),
 			IO_APIC_REDIRECTIONS_OFF + i * 2 + 1,
-			val as u32,
+			(val >> 32) as u32,
 		);
 	}
 	true

--- a/kernel/src/device/storage/nvme.rs
+++ b/kernel/src/device/storage/nvme.rs
@@ -869,15 +869,21 @@ fn handle_int(inner: &ControllerInner, qp: &QueuePair) {
 		// Do no hold `qp.inner` across a sleep point
 		let proc = {
 			let mut qp_inner = qp.inner.lock();
-			let cqe = unsafe { qp.cq.add(qp_inner.cq_head as usize).read_volatile() };
-			// Check phase bit
-			if (cqe.status & 1 != 0) != qp_inner.completion_phase {
+			let head = qp_inner.cq_head as usize;
+			let entry = unsafe { qp.cq.as_ptr().add(head) };
+			// The command identifier (low 16 bits) and the status field (high 16 bits, carrying
+			// the phase bit) occupy the same 32-bit word of the completion entry. Read that
+			// word as a unit so the phase bit can never be observed as updated while the
+			// command identifier is still stale
+			let cid_word_off = mem::offset_of!(CompletionQueueEntry, cid) / size_of::<u32>();
+			let cid_status = unsafe { entry.cast::<u32>().add(cid_word_off).read_volatile() };
+			// Check phase bit (bit 0 of the status field, the high half of the word)
+			if (cid_status >> 16 & 1 != 0) != qp_inner.completion_phase {
 				break;
 			}
-			let ent = mem::replace(
-				&mut qp_inner.entries[cqe.cid as usize],
-				QueueEntry::Completed(cqe),
-			);
+			let cid = (cid_status & 0xffff) as usize;
+			let cqe = unsafe { entry.read_volatile() };
+			let ent = mem::replace(&mut qp_inner.entries[cid], QueueEntry::Completed(cqe));
 			let QueueEntry::Submitted(proc) = ent else {
 				unreachable!();
 			};

--- a/kernel/src/device/storage/nvme.rs
+++ b/kernel/src/device/storage/nvme.rs
@@ -671,7 +671,7 @@ impl QueuePair {
 			sq: sq.cast(),
 			cq: cq.cast(),
 
-			sem: Semaphore::new(SQ_LEN),
+			sem: Semaphore::new(SQ_LEN - 1),
 			inner: Spin::new(inner),
 		})
 	}

--- a/kernel/src/device/storage/nvme.rs
+++ b/kernel/src/device/storage/nvme.rs
@@ -865,36 +865,37 @@ impl ControllerInner {
 }
 
 fn handle_int(inner: &ControllerInner, qp: &QueuePair) {
-	let mut qp_inner = qp.inner.lock();
-	let mut any = false;
 	loop {
-		let cqe = unsafe { qp.cq.add(qp_inner.cq_head as usize).read_volatile() };
-		// Check phase bit
-		if (cqe.status & 1 != 0) != qp_inner.completion_phase {
-			break;
-		}
-		// Wake up process
-		let ent = mem::replace(
-			&mut qp_inner.entries[cqe.cid as usize],
-			QueueEntry::Completed(cqe),
-		);
-		let QueueEntry::Submitted(proc) = ent else {
-			unreachable!();
-		};
-		Process::wake_from(&proc, State::Sleeping as _);
-		qp_inner.cq_head = (qp_inner.cq_head + 1) % (CQ_LEN as u32);
-		if qp_inner.cq_head == 0 {
-			qp_inner.completion_phase = !qp_inner.completion_phase;
-		}
-		any = true;
-	}
-	if any {
-		unsafe {
-			inner.bar.write::<u32>(
-				queue_doorbell_off(qp.id, true, inner.dstrd),
-				qp_inner.cq_head,
+		// Do no hold `qp.inner` across a sleep point
+		let proc = {
+			let mut qp_inner = qp.inner.lock();
+			let cqe = unsafe { qp.cq.add(qp_inner.cq_head as usize).read_volatile() };
+			// Check phase bit
+			if (cqe.status & 1 != 0) != qp_inner.completion_phase {
+				break;
+			}
+			let ent = mem::replace(
+				&mut qp_inner.entries[cqe.cid as usize],
+				QueueEntry::Completed(cqe),
 			);
-		}
+			let QueueEntry::Submitted(proc) = ent else {
+				unreachable!();
+			};
+			qp_inner.cq_head = (qp_inner.cq_head + 1) % (CQ_LEN as u32);
+			if qp_inner.cq_head == 0 {
+				qp_inner.completion_phase = !qp_inner.completion_phase;
+			}
+			// Notify the controller of the consumed completion
+			unsafe {
+				inner.bar.write::<u32>(
+					queue_doorbell_off(qp.id, true, inner.dstrd),
+					qp_inner.cq_head,
+				);
+			}
+			proc
+		};
+		// Wake up the process outside the queue-pair lock
+		Process::wake_from(&proc, State::Sleeping as _);
 	}
 }
 

--- a/kernel/src/device/tty.rs
+++ b/kernel/src/device/tty.rs
@@ -20,6 +20,7 @@
 //! communicate with it.
 
 use crate::{
+	device::serial,
 	file::{File, fs::FileOps},
 	memory::user::{UserPtr, UserSlice},
 	process::{
@@ -160,6 +161,8 @@ impl FileOps for TTYDeviceHandle {
 		let mut b: [u8; 128] = [0; 128];
 		while i < buf.len() {
 			let l = buf.copy_from_user(i, &mut b)?;
+			// TODO: this is here for debug purpose. We should find a better solution later
+			serial::PORTS[0].lock().write(&b[..l]);
 			TTY.write(&b[..l]);
 			i += l;
 		}

--- a/kernel/src/memory/cache.rs
+++ b/kernel/src/memory/cache.rs
@@ -232,11 +232,18 @@ impl RcPage {
 
 impl Drop for RcPage {
 	fn drop(&mut self) {
+		// Fast path: the page is still referenced somewhere else.
+		// This avoids taking the LRU lock on every drop (in particular from contexts that already
+		// hold it), which would deadlock.
 		if Arc::strong_count(&self.0) > 2 {
 			return;
 		}
-		unsafe {
-			LRU.lock().remove(&self.0);
+		// Lock before checking references count to avoid TOCTOU
+		let mut lru = LRU.lock();
+		if Arc::strong_count(&self.0) <= 2 {
+			unsafe {
+				lru.remove(&self.0);
+			}
 		}
 	}
 }

--- a/kernel/src/process/mem_space/mod.rs
+++ b/kernel/src/process/mem_space/mod.rs
@@ -560,7 +560,7 @@ impl MemSpace {
 		}
 		critical(|| {
 			// Update per-CPU structure
-			let prev = per_cpu().mem_space.replace(Some(this.clone()));
+			let prev = per_cpu().mem_space.lock().replace(this.clone());
 			// Update new bitmap
 			let core_id = core_id() as usize;
 			this.bound_cpus.set_bit(core_id);
@@ -579,7 +579,7 @@ impl MemSpace {
 	pub fn unbind() {
 		critical(|| {
 			// Update per-CPU structure
-			let prev = per_cpu().mem_space.replace(None);
+			let prev = per_cpu().mem_space.lock().take();
 			// Bind the kernel's vmem
 			KERNEL_VMEM.bind();
 			// Update old bitmap if any
@@ -605,7 +605,7 @@ impl MemSpace {
 	pub fn switch<F: FnOnce(&Arc<Self>) -> T, T>(this: &Arc<Self>, f: F) -> T {
 		let proc = Process::current();
 		let old = critical(|| {
-			let old = per_cpu().mem_space.get();
+			let old = per_cpu().mem_space.lock().clone();
 			*proc.active_mem_space.lock() = Some(this.clone());
 			Self::bind(this);
 			old

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -785,7 +785,10 @@ impl Process {
 		critical(|| {
 			let old_state = this.lock_state();
 			if from_mask & old_state as u8 != 0 {
-				this.state.store(STATE_LOCK | State::Running as u8, Release);
+				// Mark the process `Running` and release the state lock before enqueuing it.
+				// Otherwise it becomes runnable on another core while `STATE_LOCK` is set,
+				// resulting in a deadlock.
+				this.state.store(State::Running as u8, Release);
 				// FIXME: deadlock
 				/*#[cfg(feature = "strace")]
 				println!(
@@ -797,8 +800,9 @@ impl Process {
 				if Process::current().cmp_priority(this) == Ordering::Less {
 					preempt();
 				}
+			} else {
+				this.unlock_state();
 			}
-			this.unlock_state();
 		});
 	}
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -46,7 +46,7 @@ use crate::{
 		pid::{IDLE_PID, INIT_PID, PidHandle},
 		rusage::Rusage,
 		scheduler::{
-			cpu, critical, dequeue, enqueue, preempt, switch,
+			cpu, critical, dequeue, enqueue, enqueue_current, preempt, switch,
 			switch::{KThreadEntry, idle_task, save_segments},
 		},
 		signal::{AltStack, SIGNALS_COUNT, SigSet, SignalAction},
@@ -1105,7 +1105,7 @@ pub fn set_state(new_state: State) {
 		);*/
 		// Enqueue or dequeue the process
 		if new_state == State::Running {
-			enqueue(&proc);
+			enqueue_current(&proc);
 		} else {
 			dequeue(&proc);
 		}
@@ -1154,7 +1154,7 @@ pub fn cancel_sleep() {
 	let proc = Process::current();
 	proc.state.store(State::Running as u8, Release);
 	// `set_state` has dequeued the process
-	enqueue(&proc);
+	enqueue_current(&proc);
 }
 
 /// Exits the current process with the given `status`.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -767,6 +767,19 @@ impl Process {
 		self.state.fetch_and(!STATE_LOCK, Release);
 	}
 
+	/// Waits until the process is no longer running on any CPU.
+	///
+	/// A non-[`State::Running`] process keeps its state write-locked from the moment it stops
+	/// running until its context switch is effective ([`switch`] calls [`Self::unlock_state`]).
+	///
+	/// This function is used to avoid reclaiming resources of a process that has been marked as
+	/// `Zombie` but whose final context switch has not happened yet.
+	pub fn wait_off_cpu(&self) {
+		while unlikely(self.state.load(Acquire) & STATE_LOCK != 0) {
+			hint::spin_loop();
+		}
+	}
+
 	/// Wakes up the process if it is currently in state present in `from_mask`.
 	pub fn wake_from(this: &Arc<Self>, from_mask: u8) {
 		critical(|| {
@@ -1135,10 +1148,11 @@ pub fn set_state(new_state: State) {
 			// Set vfork as done just in case
 			proc.vfork_wake();
 		}
-		// Sleeping or stopped processes are unlocked only once rescheduled, to prevent another
-		// core from waking them up before they are actually asleep
+		// Sleeping, stopped and zombie processes are unlocked only once rescheduled, to prevent
+		// another core from waking them up or reclaiming their resources before they have
+		// actually switched off this core
 		match new_state {
-			State::Running | State::Zombie => proc.unlock_state(),
+			State::Running => proc.unlock_state(),
 			// Disable interruptions to prevent deadlock if an interruption tries to wake up the
 			// process
 			_ => cli(),

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -426,7 +426,7 @@ pub(crate) fn register_callbacks() -> AllocResult<()> {
 	let page_fault_callback = |_id: u32, code: u32, frame: &mut IntFrame, ring: u8| {
 		let accessed_addr = VirtAddr(register_get!("cr2"));
 		let pc = frame.get_program_counter();
-		let Some(mem_space) = per_cpu().mem_space.get() else {
+		let Some(mem_space) = per_cpu().mem_space.lock().clone() else {
 			panic::with_frame(frame);
 		};
 		// Check access

--- a/kernel/src/process/scheduler/cpu/mod.rs
+++ b/kernel/src/process/scheduler/cpu/mod.rs
@@ -41,7 +41,7 @@ use utils::{
 	collections::vec::Vec,
 	errno::{AllocResult, CollectResult},
 	list,
-	ptr::arc::{AtomicArc, AtomicOptionalArc},
+	ptr::arc::Arc,
 };
 // TODO allow to declare per-core variables everywhere in the codebase using a dedicated ELF
 // section
@@ -90,9 +90,7 @@ pub struct PerCpu {
 	pub preempt_counter: AtomicU32,
 
 	/// Attached memory space
-	///
-	/// The pointer stored by this field is returned by `Arc::into_raw`
-	pub mem_space: AtomicOptionalArc<MemSpace>,
+	pub mem_space: IntSpin<Option<Arc<MemSpace>>>,
 
 	/// Queue of deferred calls to be executed on this core
 	pub(super) deferred_calls: DeferredCallQueue,
@@ -125,14 +123,14 @@ impl PerCpu {
 					queue: list!(Process, sched_node),
 					len: 0,
 				}),
-				cur_proc: AtomicArc::from(idle_task.clone()),
+				cur_proc: IntSpin::new(idle_task.clone()),
 
 				idle_task: idle_task.clone(),
 			},
 			tick_period: AtomicU64::new(0),
 			preempt_counter: AtomicU32::new(1 << 31),
 
-			mem_space: AtomicOptionalArc::new(),
+			mem_space: IntSpin::new(None),
 
 			deferred_calls: DeferredCallQueue::new(),
 		})

--- a/kernel/src/process/scheduler/mod.rs
+++ b/kernel/src/process/scheduler/mod.rs
@@ -29,7 +29,7 @@ pub mod switch;
 use crate::{
 	arch::{
 		core_id,
-		x86::{cli, idt::IntFrame},
+		x86::{apic, apic::IpiDeliveryMode, cli, idt::IntFrame},
 	},
 	process::{
 		Process, State,
@@ -102,14 +102,38 @@ impl Scheduler {
 		self.run_queue.lock().len
 	}
 
-	/// Returns the next process to run with its PID.
+	/// Selects the next process to run and atomically makes it the current process.
 	///
-	/// If no process is left to run, the function returns `None`.
-	fn get_next_process(&self) -> Option<Arc<Process>> {
+	/// Returns the previous and next processes as raw pointers, for the context switch, or `None`
+	/// if the next process is the same as the current one (nothing to do).
+	fn pick_and_switch(&self) -> Option<(*const Process, *const Process)> {
+		// Held all along to avoid concurrency issues, because the [`rebalance`] task holds it too
 		let mut queue = self.run_queue.lock();
-		let proc = queue.queue.front()?;
-		queue.queue.rotate_left();
-		Some(proc)
+		let next = match queue.queue.front() {
+			Some(proc) => {
+				queue.queue.rotate_left();
+				proc
+			}
+			None => self.idle_task.clone(),
+		};
+		let mut cur = self.cur_proc.lock();
+		// If the process to run is the current, do nothing
+		if ptr::eq(next.as_ref(), cur.as_ref()) {
+			return None;
+		}
+		// Update the idle bitmap if necessary
+		if cur.is_idle_task() {
+			IDLE_CPUS.clear_bit(core_id() as _);
+		} else if next.is_idle_task() {
+			IDLE_CPUS.set_bit(core_id() as _);
+		}
+		// Swap current running process. We use pointers to avoid cloning the Arc
+		per_cpu()
+			.kernel_stack
+			.store(next.kernel_stack.top().as_ptr() as _, Release);
+		let next_ptr = Arc::as_ptr(&next);
+		let prev = mem::replace(&mut *cur, next);
+		Some((Arc::as_ptr(&prev), next_ptr))
 	}
 }
 
@@ -170,6 +194,34 @@ pub(crate) fn enqueue(proc: &Arc<Process>) {
 		cpu.apic_id
 	);*/
 	// Enqueue
+	{
+		let mut run_queue = cpu.sched.run_queue.lock();
+		run_queue.queue.insert_back(proc.clone());
+		run_queue.len += 1;
+		let mut links = proc.links.lock();
+		debug_assert!(links.cur_cpu.is_none());
+		links.cur_cpu = Some(cpu);
+		links.last_cpu = Some(cpu);
+	}
+	// If the process has been enqueued on another core, notify it with a reschedule IPI
+	if !ptr::eq(cpu, per_cpu()) {
+		apic::ipi(cpu.apic_id, IpiDeliveryMode::Fixed, defer::INT);
+	}
+}
+
+/// Re-attaches `proc` to the **current** core's run queue.
+///
+/// Unlike [`enqueue`], this never load-balances the process onto another core. It must only be
+/// used for a process that is *currently running on the calling core* (i.e. it is this core's
+/// `cur_proc`) and that has been dequeued — for example after cancelling a sleep.
+///
+/// Using [`enqueue`] in that situation is a bug: its load-balancing may place the still-running
+/// process into another core's run queue, letting that core schedule it concurrently. Since a
+/// process's kernel stack is shared across whichever cores run it, that causes memory corruption
+/// (the "double-run" bug).
+pub(crate) fn enqueue_current(proc: &Arc<Process>) {
+	debug_assert_eq!(proc.get_state(), State::Running);
+	let cpu = per_cpu();
 	let mut run_queue = cpu.sched.run_queue.lock();
 	run_queue.queue.insert_back(proc.clone());
 	run_queue.len += 1;
@@ -311,27 +363,8 @@ pub fn schedule() {
 	debug_assert_eq!(old_preempt_counter & !PREEMPT_FLAG, 0);
 	// Make deferred calls
 	defer::consume();
-	let sched = &per_cpu().sched;
-	let (prev, next) = {
-		let prev = sched.cur_proc.get();
-		// Find the next process to run
-		let next = sched
-			.get_next_process()
-			.unwrap_or_else(|| sched.idle_task.clone());
-		// If the process to run is the current, do nothing
-		if ptr::eq(next.as_ref(), prev.as_ref()) {
-			return;
-		}
-		// Update the idle bitmap if necessary
-		if prev.is_idle_task() {
-			IDLE_CPUS.clear_bit(core_id() as _);
-		} else if next.is_idle_task() {
-			IDLE_CPUS.set_bit(core_id() as _);
-		}
-		// Swap current running process. We use pointers to avoid cloning the Arc
-		let next_ptr = Arc::as_ptr(&next);
-		let prev = sched.swap_current_process(next);
-		(Arc::as_ptr(&prev), next_ptr)
+	let Some((prev, next)) = per_cpu().sched.pick_and_switch() else {
+		return;
 	};
 	unsafe {
 		switch(prev, next);

--- a/kernel/src/process/scheduler/mod.rs
+++ b/kernel/src/process/scheduler/mod.rs
@@ -212,20 +212,22 @@ pub(crate) fn enqueue(proc: &Arc<Process>) {
 /// Re-attaches `proc` to the **current** core's run queue.
 ///
 /// Unlike [`enqueue`], this never load-balances the process onto another core. It must only be
-/// used for a process that is *currently running on the calling core* (i.e. it is this core's
-/// `cur_proc`) and that has been dequeued — for example after cancelling a sleep.
-///
-/// Using [`enqueue`] in that situation is a bug: its load-balancing may place the still-running
-/// process into another core's run queue, letting that core schedule it concurrently. Since a
-/// process's kernel stack is shared across whichever cores run it, that causes memory corruption
-/// (the "double-run" bug).
+/// used for a process that is *currently running on the calling core* (example: it is this core's
+/// current process) and that has been dequeued. Using [`enqueue`] in that situation may result in
+/// the process running on two cores at once (critical bug).
 pub(crate) fn enqueue_current(proc: &Arc<Process>) {
 	debug_assert_eq!(proc.get_state(), State::Running);
 	let cpu = per_cpu();
+	// Lock order is always run_queue then links (see `enqueue`/`dequeue`), to avoid deadlocks
 	let mut run_queue = cpu.sched.run_queue.lock();
+	let mut links = proc.links.lock();
+	// If the process is already enqueued, do nothing
+	if let Some(cur) = links.cur_cpu {
+		debug_assert!(ptr::eq(cur, cpu));
+		return;
+	}
 	run_queue.queue.insert_back(proc.clone());
 	run_queue.len += 1;
-	let mut links = proc.links.lock();
 	links.cur_cpu = Some(cpu);
 	links.last_cpu = Some(cpu);
 }

--- a/kernel/src/process/scheduler/mod.rs
+++ b/kernel/src/process/scheduler/mod.rs
@@ -41,15 +41,11 @@ use crate::{
 use core::{
 	cmp::Ordering,
 	hint::unlikely,
-	mem::swap,
-	ptr,
+	mem, ptr,
 	sync::atomic::Ordering::{Relaxed, Release},
 };
 use cpu::{CPU, IDLE_CPUS, PerCpu};
-use utils::{
-	list_type,
-	ptr::arc::{Arc, AtomicArc},
-};
+use utils::{list_type, ptr::arc::Arc};
 
 /// Flag in the preempt counter, telling whether preemption has been requested
 const PREEMPT_FLAG: u32 = 1 << 31;
@@ -73,7 +69,7 @@ pub struct Scheduler {
 	/// Run queue
 	run_queue: IntSpin<RunQueue>,
 	/// The currently running process
-	cur_proc: AtomicArc<Process>,
+	cur_proc: IntSpin<Arc<Process>>,
 
 	/// The task used to make the current CPU idle
 	idle_task: Arc<Process>,
@@ -83,7 +79,7 @@ impl Scheduler {
 	/// Returns the current running process.
 	#[inline]
 	pub fn get_current_process(&self) -> Arc<Process> {
-		self.cur_proc.get()
+		self.cur_proc.lock().clone()
 	}
 
 	/// Swaps the current running process for `new`, returning the previous.
@@ -91,7 +87,7 @@ impl Scheduler {
 		per_cpu()
 			.kernel_stack
 			.store(new.kernel_stack.top().as_ptr() as _, Release);
-		self.cur_proc.replace(new)
+		mem::replace(&mut *self.cur_proc.lock(), new)
 	}
 
 	/// Tells whether this scheduler can immediately run `proc`
@@ -242,8 +238,8 @@ fn rebalance() {
 	let mut src_queue = src.sched.run_queue.lock();
 	// Process counts might have changed before we locked
 	if dst_queue.len > src_queue.len {
-		swap(&mut dst, &mut src);
-		swap(&mut dst_queue, &mut src_queue);
+		mem::swap(&mut dst, &mut src);
+		mem::swap(&mut dst_queue, &mut src_queue);
 	}
 	// No need to do anything if no core has more than one process
 	if src_queue.len <= 1 {

--- a/kernel/src/process/scheduler/switch.rs
+++ b/kernel/src/process/scheduler/switch.rs
@@ -236,9 +236,6 @@ pub extern "C" fn finish(prev: &Process, next: &Process) {
 	fxrstor(&next.fpu.lock());
 	// Save segments
 	save_segments(prev);
-	// State is saved for `prev`, we may unlock its state so that it can be resumed if it is
-	// currently sleeping
-	prev.unlock_state();
 	// Restore TLS entries from `next`
 	next.tls
 		.lock()
@@ -260,6 +257,11 @@ pub extern "C" fn finish(prev: &Process, next: &Process) {
 			.tss()
 			.set_kernel_stack(next.kernel_stack.top().as_ptr());
 	}
+	// `prev` is fully switched off this core: its state is saved and its memory space has been
+	// unbound. Only now unlock its state, so that another core may resume it (if sleeping) or
+	// reclaim it (if it is a zombie). Unlocking earlier would let a concurrent reaper free `prev`
+	// (and its memory space) while we are still switching away from it
+	prev.unlock_state();
 }
 
 #[cfg(target_arch = "x86")]

--- a/kernel/src/syscall/wait.rs
+++ b/kernel/src/syscall/wait.rs
@@ -126,6 +126,8 @@ fn get_waitable(
 	// Remove zombie process if requested
 	let pid = proc.get_pid();
 	if options & WNOWAIT == 0 && proc.get_state() == State::Zombie {
+		// Wait for the context to be finished before reclaiming resources
+		proc.wait_off_cpu();
 		Process::remove(proc);
 	}
 	Ok(Some(pid))

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -77,7 +77,7 @@ pub fn sleep_for(clock: Clock, delay: Timestamp, remain: &mut Timestamp) -> ERes
 /// Initializes timekeeping
 pub(crate) fn init() -> EResult<()> {
 	clock::init(rtc::read_time());
-	const FREQUENCY: u32 = 1024;
+	const FREQUENCY: u32 = 128;
 	rtc::set_frequency(FREQUENCY);
 	if apic::is_present() {
 		apic::redirect_int(0x8, core_id(), rtc::INTERRUPT_VECTOR);
@@ -85,7 +85,6 @@ pub(crate) fn init() -> EResult<()> {
 	unsafe {
 		int::register_callback(rtc::INTERRUPT_VECTOR as _, move |_, _, _, _| {
 			rtc::reset();
-			// FIXME: we are loosing precision here
 			clock::update((1_000_000_000 / FREQUENCY) as _);
 			timer::tick();
 		})?;

--- a/utils/src/ptr/arc.rs
+++ b/utils/src/ptr/arc.rs
@@ -30,9 +30,9 @@ use core::{
 	mem::{ManuallyDrop, offset_of},
 	ops::{CoerceUnsized, Deref, DispatchFromDyn},
 	ptr,
-	ptr::{NonNull, drop_in_place, null, null_mut},
+	ptr::{NonNull, drop_in_place},
 	sync::atomic::{
-		AtomicPtr, AtomicUsize,
+		AtomicUsize,
 		Ordering::{Relaxed, Release},
 	},
 };
@@ -281,76 +281,5 @@ impl<T: ?Sized> Drop for Arc<T> {
 			let layout = Layout::for_value(inner);
 			__dealloc(self.inner.cast(), layout);
 		}
-	}
-}
-
-/// Relaxed atomic optional [`Arc`] storage.
-#[derive(Default)]
-pub struct AtomicOptionalArc<T>(AtomicPtr<T>);
-
-impl<T> From<Arc<T>> for AtomicOptionalArc<T> {
-	fn from(val: Arc<T>) -> Self {
-		let ptr = Arc::into_raw(val);
-		Self(AtomicPtr::new(ptr as _))
-	}
-}
-
-impl<T> AtomicOptionalArc<T> {
-	/// Creates a new instance.
-	#[inline]
-	pub const fn new() -> Self {
-		Self(AtomicPtr::new(null_mut()))
-	}
-
-	/// Get a copy of the inner [`Arc`].
-	pub fn get(&self) -> Option<Arc<T>> {
-		let ptr = self.0.load(Relaxed);
-		(!ptr.is_null()).then(|| {
-			let arc = unsafe { Arc::from_raw(ptr) };
-			// Increment reference counter
-			mem::forget(arc.clone());
-			arc
-		})
-	}
-
-	/// Swaps the inner value for `val`, returning the previous.
-	pub fn replace(&self, val: Option<Arc<T>>) -> Option<Arc<T>> {
-		let new = val.map(Arc::into_raw).unwrap_or(null());
-		let old = self.0.swap(new as _, Relaxed);
-		(!old.is_null()).then(|| unsafe { Arc::from_raw(old) })
-	}
-
-	/// Set the inner [`Arc`].
-	#[inline]
-	pub fn set(&self, val: Option<Arc<T>>) {
-		self.replace(val);
-	}
-}
-/// Relaxed atomic [`Arc`] storage.
-pub struct AtomicArc<T>(AtomicOptionalArc<T>);
-
-impl<T> From<Arc<T>> for AtomicArc<T> {
-	fn from(val: Arc<T>) -> Self {
-		Self(AtomicOptionalArc::from(val))
-	}
-}
-
-impl<T> AtomicArc<T> {
-	/// Get a copy of the inner [`Arc`].
-	#[inline]
-	pub fn get(&self) -> Arc<T> {
-		self.0.get().unwrap()
-	}
-
-	/// Swaps the inner value for `val`, returning the previous.
-	#[inline]
-	pub fn replace(&self, val: Arc<T>) -> Arc<T> {
-		self.0.replace(Some(val)).unwrap()
-	}
-
-	/// Set the inner [`Arc`].
-	#[inline]
-	pub fn set(&self, val: Arc<T>) {
-		self.replace(val);
 	}
 }


### PR DESCRIPTION
Fixing concurrency issues in the scheduler when using SMP:
- Invalid register value in `redirect_int`
- `AtomicArc`/`AtomicOptionalArc` are unsound by construction, remove them entirely
- NVMe semaphore permit count off-by-one error
- Process enqueued on two different CPUs after we cancel sleeping
- Zombie process resources reclaimed by a CPU core while its ending context is still running on another core
- `wake_from` keeping the state locked after switching state to `Running` and enqueuing (deadlock)
- Make the NVMe driver read the CID and status fields from completion queue entries as a single dword
- Reduce the RTC resolution. When too high, this is taking to much CPU time, making the CI extremely slow

The final fix that made the CI pass is the RTC fix.
Note that it is not a definitive fix as it is dependent on the speed of system's CPU.
A very very slow CPU would make the issue appear again.
A final, definitive fix will have to be made later.